### PR TITLE
Use multi-stage build for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,267 @@
+# Created by .ignore support plugin (hsz.mobi)
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Emacs template
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+*.iml
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.6-alpine3.7 as common
 MAINTAINER fiaas@googlegroups.com
 # Install any binary package dependencies here
-RUN apk update && apk add \
+RUN apk --no-cache add \
     yaml
 
 FROM common as build
 # Install build tools, and build wheels of all dependencies
-RUN apk update && apk add \
+RUN apk --no-cache add \
     build-base \
     git \
     yaml-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
-FROM gliderlabs/alpine:3.6
+FROM python:3.6-alpine3.7 as common
 MAINTAINER fiaas@googlegroups.com
-RUN apk-install python3=3.6.1-r3 ca-certificates=20161130-r2 && \
-    python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade pip && \
-    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-    rm -r /root/.cache
+# Install any binary package dependencies here
+RUN apk update && apk add \
+    yaml
+
+FROM common as build
+# Install build tools, and build wheels of all dependencies
+RUN apk update && apk add \
+    build-base \
+    git \
+    yaml-dev
 COPY . /skipper
 WORKDIR /skipper
+RUN pip wheel . --wheel-dir=/wheels/
+
+FROM common as production
+# Get rid of all build dependencies, install application using only pre-built binary wheels
+COPY --from=build /wheels/ /wheels/
+RUN pip install --no-index --find-links=/wheels/ --only-binary all /wheels/fiaas_skipper*.whl
 EXPOSE 5000
-RUN pip3 install .
 CMD ["skipper"]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email="fiaas@googlegroups.com",
     version=version(),
     packages=find_packages(exclude=("tests",)),
-    zip_safe=False,
+    zip_safe=True,
     # Requirements
     install_requires=GENERIC_REQ + WEB_REQ,
     setup_requires=['pytest-runner', 'wheel', 'setuptools_scm'],


### PR DESCRIPTION
The setup here is really quite simple:

* First we create a stage named `common`, where we install anything that is needed both while building and at runtime. In our case, it's just libyaml.
* Second, we create a stage named `build`, based on `common`. Here we install build-tools, needed headers etc. Then we build binary wheels of all our dependencies and our application.
* Last, we create a stage named `production`, based on `common` again. This gets rid of all the tools and stuff needed to build the binaries. We then copy the binary wheels from `build` and use those to install the application.
 