### PR TITLE
Clean up chart, and remove some unneeded/unwanted options

### DIFF
--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -45,10 +45,10 @@ def main():
         release_channel_factory = ReleaseChannelFactory(cfg.baseurl)
         if cfg.enable_crd_support:
             deployer = CrdDeployer(cluster=cluster, release_channel_factory=release_channel_factory,
-                                   bootstrap=CrdBootstrapper(), ingress_suffix=cfg.ingress_suffix)
-        if cfg.enable_tpr_support:
+                                   bootstrap=CrdBootstrapper())
+        elif cfg.enable_tpr_support:
             deployer = TprDeployer(cluster=cluster, release_channel_factory=release_channel_factory,
-                                   bootstrap=TprBootstrapper(), ingress_suffix=cfg.ingress_suffix)
+                                   bootstrap=TprBootstrapper())
         webapp = create_webapp(deployer, cluster)
         Main(webapp=webapp, config=cfg).run()
     except BaseException:

--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -3,10 +3,10 @@
 from __future__ import absolute_import
 
 import logging
-import os
 from argparse import Namespace
 
 import configargparse
+import os
 
 DEFAULT_CONFIG_FILE = "/var/run/config/fiaas/cluster_config.yaml"
 
@@ -41,9 +41,6 @@ class Configuration(Namespace):
         parser.add_argument("--enable-crd-support", help="Enable Custom Resource Definition support.",
                             action="store_true")
         parser.add_argument("--baseurl", help="Url to server hosting release channel meta data.")
-        parser.add_argument("--ingress-suffix",
-                            help="Suffix to use for ingress",
-                            default='ingress.cre-pro.schibsted.io')
         api_parser = parser.add_argument_group("API server")
         api_parser.add_argument("--api-server", help="Address of the api-server to use (IP or name)",
                                 default="https://kubernetes.default.svc.cluster.local")

--- a/fiaas_skipper/deploy/crd/deployer.py
+++ b/fiaas_skipper/deploy/crd/deployer.py
@@ -7,7 +7,7 @@ import logging
 from k8s.client import ClientError
 
 from .types import FiaasApplicationSpec, FiaasApplication
-from ..deploy import Deployer, generate_config, default_config_template
+from ..deploy import Deployer, default_config_template
 
 LOG = logging.getLogger(__name__)
 
@@ -18,13 +18,11 @@ class CrdDeployer(Deployer):
         try:
             fdd_app = FiaasApplication(metadata=self._create_metadata(deployment_config),
                                        spec=self._create_application_spec(name=deployment_config.name,
-                                                                          namespace=deployment_config.namespace,
                                                                           image=channel.metadata['image']))
             fdd_app.save()
         except ClientError as e:
             if e.response.json()['reason'] != 'AlreadyExists':
                 raise
 
-    def _create_application_spec(self, name, namespace, image):
-        config = generate_config(default_config_template, namespace, self._ingress_suffix)
-        return FiaasApplicationSpec(application=name, image=image, config=config)
+    def _create_application_spec(self, name, image):
+        return FiaasApplicationSpec(application=name, image=image, config=default_config_template)

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -22,11 +22,10 @@ fiaas_enabled_namespaces_gauge = Gauge("fiaas_enabled_namespaces", "Number of na
 
 
 class Deployer(object):
-    def __init__(self, cluster, release_channel_factory, bootstrap, ingress_suffix):
+    def __init__(self, cluster, release_channel_factory, bootstrap):
         self._cluster = cluster
         self._release_channel_factory = release_channel_factory
         self._bootstrap = bootstrap
-        self._ingress_suffix = ingress_suffix
 
     def deploy(self):
         deploy_counter.inc()
@@ -108,13 +107,7 @@ def requires_bootstrap(deployment_config):
     except NotFound:
         return True
     except Exception as e:
-        LOG.warn(e, exc_info=True)
-
-
-def generate_config(template, namespace, ingress_suffix):
-    config = dict(template)
-    config['host'] = "".join([NAME, '-', namespace, '.', ingress_suffix])
-    return config
+        LOG.warning(e, exc_info=True)
 
 
 _resource_stream = pkg_resources.resource_stream(__name__, "fiaas.yml")

--- a/fiaas_skipper/deploy/tpr/deployer.py
+++ b/fiaas_skipper/deploy/tpr/deployer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import logging
 
 from .types import PaasbetaApplication, PaasbetaApplicationSpec
-from ..deploy import Deployer, generate_config, default_config_template
+from ..deploy import Deployer, default_config_template
 
 LOG = logging.getLogger(__name__)
 
@@ -15,12 +15,8 @@ class TprDeployer(Deployer):
         LOG.info("Deploying %s to %s", deployment_config.name, deployment_config.namespace)
         pba = PaasbetaApplication(metadata=self._create_metadata(deployment_config),
                                   spec=self._create_paasbetaapplicationspec(name=deployment_config.name,
-                                                                            namespace=deployment_config.namespace,
                                                                             image=channel.metadata['image']))
         pba.save()
 
-    def _create_paasbetaapplicationspec(self, name, namespace, image):
-        config = generate_config(template=default_config_template,
-                                 namespace=namespace,
-                                 ingress_suffix=self._ingress_suffix)
-        return PaasbetaApplicationSpec(application=name, image=image, config=config)
+    def _create_paasbetaapplicationspec(self, name, image):
+        return PaasbetaApplicationSpec(application=name, image=image, config=default_config_template)

--- a/helm/fiaas-skipper/Chart.yaml
+++ b/helm/fiaas-skipper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: Install fiaas skipper
+description: Skipper controls deployment and updates of FIAAS components
 name: fiaas-skipper
 home: https://github.com/fiaas/skipper
 version: 0.1.0

--- a/helm/fiaas-skipper/templates/config_map.yaml
+++ b/helm/fiaas-skipper/templates/config_map.yaml
@@ -10,11 +10,6 @@ metadata:
 data:
   cluster_config.yaml: |-
     log-format: plain
-    ingress-suffix:
-    - "{{ .Values.ingress.domainName }}"
-    {{with .Values.environment}}environment: {{.}}{{end}}
-    {{with .Values.infrastructure}}infrastructure: {{.}}{{end}}
     {{with .Values.TPR}}enable-tpr-support: {{.}}{{end}}
     {{with .Values.CRD}}enable-crd-support: {{.}}{{end}}
     {{with .Values.baseurl}}baseurl: {{.}}{{end}}
-    {{with .Values.ingressSuffix}}ingress-suffix: {{.}}{{end}}

--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -27,11 +27,6 @@ spec:
       - name: "{{ .Values.name }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        env:
-        - name: IMAGE
-          value: "{{ .Values.image.repository }}"
-        - name: VERSION
-          value: "{{ .Values.image.tag }}"
         ports:
         - containerPort: 5000
           name: http5000

--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -1,10 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
   labels:
     app: "{{ .Values.name }}"
   name: "{{ .Values.name }}"

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -5,14 +5,10 @@ image:
   pullPolicy: Always
 ingress:
   fqdn: fiaas-skipper.yourcluster.local
-  domainName: yourcluster.local
   enableTLS: true
 deployment:
   # include the resource requests and limits
   includeResourceUsage: true
-environment: dev
-infrastructure: diy
 TPR: false
-CRD: false
+CRD: true
 baseurl: 'http://localhost/release/channel/url'
-ingressSuffix: example.com

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -20,8 +20,7 @@ class TestApi(object):
         bootstrap = Mock()
         return Deployer(cluster=cluster,
                         release_channel_factory=release_channel_factory,
-                        bootstrap=bootstrap,
-                        ingress_suffix='example.com')
+                        bootstrap=bootstrap)
 
     @pytest.fixture
     def cluster(self):


### PR DESCRIPTION
Cleaned up the chart a bit.

I realized that the only reason skipper needs an ingress-suffix configured is because it uses it to generate `host` values in the created TPR/CRD objects for fiaas-deploy-daemon. We don't really care about the web-interface of fiaas-deploy-daemon, especially not from outside the cluster, so if the ingress points to a randomly selected fiaas-deploy-daemon, it's not really a big problem. We have plans to make ingress per namespace work as expected, and once we do, this will be solved. Until then, we don't really need it. Once we come to that conclusion, we can just remove all the code that has to to with passing ingress-suffix around, making the chart simpler in the process.

Worth noticing: Only a single test failed/needed to be changed to handle the sweeping changes I did, and that was only a minor edit that intellij handled for me :disappointed: 