### PR TITLE
Extend spec file to include ingress paths

### DIFF
--- a/helm/fiaas-skipper/fiaas.yaml
+++ b/helm/fiaas-skipper/fiaas.yaml
@@ -14,3 +14,8 @@ healthchecks:
       path: /healthz
 config:
   volume: true
+ingress:
+  - host:
+    paths:
+      - path: /
+        port: http


### PR DESCRIPTION
Although these should be the defaults (or at least I am assuming they are) not supplying them results in errors when creating ingress objects. By setting it like this the problem is avoided.