### PR TITLE
Adjust liveness probe to accomodate for potential slow responses

### DIFF
--- a/fiaas_skipper/web/templates/status.html
+++ b/fiaas_skipper/web/templates/status.html
@@ -72,7 +72,7 @@
          });
       }
     });
-    window.setTimeout(function() { getStatus() }, 5000);
+    window.setTimeout(function() { getStatus() }, 20000);
   }
 
   $().ready(function() {

--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -36,12 +36,14 @@ spec:
           protocol: TCP
         livenessProbe:
           initialDelaySeconds: 10
+          timeoutSeconds: 20
           httpGet:
             path: /healthz
             port: http5000
             scheme: HTTP
         readinessProbe:
           initialDelaySeconds: 10
+          timeoutSeconds: 20
           httpGet:
             path: /healthz
             port: http5000


### PR DESCRIPTION
Reducing ui status refresh rate and increasing liveness probe timeout value as
getting the status across the cluster can be a timeconsuming operation.