### PR TITLE
Extend fiaas-deploy-daemon spec file

### DIFF
--- a/helm/fiaas-skipper/fiaas.yaml
+++ b/helm/fiaas-skipper/fiaas.yaml
@@ -14,3 +14,6 @@ healthchecks:
       path: /healthz
 config:
   volume: true
+metrics:
+  prometheus:
+    path: /internal-backstage/prometheus


### PR DESCRIPTION
This adds annotations for log-aggregation and correct endpoint for scraping prometheus metrics for fiaas-deploy-daemon.