### PR TITLE
Switch to bare pod bootstrapper

### DIFF
--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -29,7 +29,7 @@ class BarePodBootstrapper(object):
             pass
         pod_spec = _create_pod_spec(self._cmd_args, channel)
         pod_metadata = _create_pod_metadata(deployment_config, spec_config)
-        pod = Pod.get_or_create(metadata=pod_metadata, spec=pod_spec)
+        pod = Pod(metadata=pod_metadata, spec=pod_spec)
         pod.save()
 
 
@@ -47,6 +47,7 @@ def _create_pod_metadata(deployment_config, spec_config):
     pod_annotations = _get_pod_annotations(spec_config)
     pod_metadata = ObjectMeta(name=BOOTSTRAP_POD_NAME,
                               annotations=pod_annotations,
+                              labels={"app": BOOTSTRAP_POD_NAME},
                               namespace=deployment_config.namespace)
     return pod_metadata
 

--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -3,40 +3,17 @@
 from __future__ import absolute_import
 
 import logging
-import random
-import string
 
+from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
-from k8s.models.job import JobSpec, Job
-from k8s.models.pod import Container, PodSpec, PodTemplateSpec, Pod
+from k8s.models.pod import Container, PodSpec, Pod
 from prometheus_client import Counter
+
+BOOTSTRAP_POD_NAME = "fiaas-deploy-daemon-bootstrap"
 
 LOG = logging.getLogger(__name__)
 
 bootstrap_counter = Counter("bootstraps_triggered", "A deployment caused a bootstrap to be triggered")
-
-
-class BatchJobsBootstrapper(object):
-    def __init__(self, cmd_args=()):
-        self._cmd_args = cmd_args
-
-    def __call__(self, deployment_config, channel, spec_config=None):
-        bootstrap_counter.inc()
-        LOG.info("Bootstrapping %s in %s", deployment_config.name, deployment_config.namespace)
-        object_meta = ObjectMeta(generateName="bootstrap-fiaas-",
-                                 namespace=deployment_config.namespace)
-        container = Container(
-            name="fiaas-deploy-daemon-bootstrap",
-            image=channel.metadata['image'],
-            command=["fiaas-deploy-daemon-bootstrap"] + self._cmd_args
-        )
-        pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")
-        pod_annotations = _get_pod_annotations(spec_config)
-        pod_metadata = ObjectMeta(name="fiaas-deploy-daemon-bootstrap", annotations=pod_annotations)
-        pod_template_spec = PodTemplateSpec(metadata=pod_metadata, spec=pod_spec)
-        job_spec = JobSpec(template=pod_template_spec, backoffLimit=5)
-        job = Job(metadata=object_meta, spec=job_spec)
-        job.save()
 
 
 class BarePodBootstrapper(object):
@@ -46,19 +23,32 @@ class BarePodBootstrapper(object):
     def __call__(self, deployment_config, channel, spec_config=None):
         bootstrap_counter.inc()
         LOG.info("Bootstrapping %s in %s", deployment_config.name, deployment_config.namespace)
-        container = Container(
-            name="fiaas-deploy-daemon-bootstrap",
-            image=channel.metadata['image'],
-            command=["fiaas-deploy-daemon-bootstrap"] + self._cmd_args
-        )
-        pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")
-        pod_annotations = _get_pod_annotations(spec_config)
-        pod_metadata = ObjectMeta(name="fiaas-deploy-daemon-bootstrap-" +
-                                       ''.join(random.choices(string.ascii_lowercase, k=8)),
-                                  annotations=pod_annotations,
-                                  namespace=deployment_config.namespace)
-        pod = Pod(metadata=pod_metadata, spec=pod_spec)
+        try:
+            Pod.delete(name=BOOTSTRAP_POD_NAME, namespace=deployment_config.namespace)
+        except NotFound:
+            pass
+        pod_spec = _create_pod_spec(self._cmd_args, channel)
+        pod_metadata = _create_pod_metadata(deployment_config, spec_config)
+        pod = Pod.get_or_create(metadata=pod_metadata, spec=pod_spec)
         pod.save()
+
+
+def _create_pod_spec(args, channel):
+    container = Container(
+        name="fiaas-deploy-daemon-bootstrap",
+        image=channel.metadata['image'],
+        command=["fiaas-deploy-daemon-bootstrap"] + args
+    )
+    pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")
+    return pod_spec
+
+
+def _create_pod_metadata(deployment_config, spec_config):
+    pod_annotations = _get_pod_annotations(spec_config)
+    pod_metadata = ObjectMeta(name=BOOTSTRAP_POD_NAME,
+                              annotations=pod_annotations,
+                              namespace=deployment_config.namespace)
+    return pod_metadata
 
 
 def _get_pod_annotations(spec_config):

--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -3,10 +3,11 @@
 from __future__ import absolute_import
 
 import logging
+import random
+import string
 
 from k8s.models.common import ObjectMeta
-from k8s.models.job import JobSpec, Job
-from k8s.models.pod import Container, PodSpec, PodTemplateSpec
+from k8s.models.pod import Container, PodSpec, PodTemplateSpec, Pod
 from prometheus_client import Counter
 
 LOG = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ LOG = logging.getLogger(__name__)
 bootstrap_counter = Counter("bootstraps_triggered", "A deployment caused a bootstrap to be triggered")
 
 
-class Bootstrapper(object):
+class BatchJobsBootstrapper(object):
     def __init__(self, cmd_args=()):
         self._cmd_args = cmd_args
 
@@ -32,9 +33,31 @@ class Bootstrapper(object):
         pod_annotations = _get_pod_annotations(spec_config)
         pod_metadata = ObjectMeta(name="fiaas-deploy-daemon-bootstrap", annotations=pod_annotations)
         pod_template_spec = PodTemplateSpec(metadata=pod_metadata, spec=pod_spec)
-        job_spec = JobSpec(template=pod_template_spec)
+        job_spec = JobSpec(template=pod_template_spec, backoffLimit=5)
         job = Job(metadata=object_meta, spec=job_spec)
         job.save()
+
+
+class BarePodBootstrapper(object):
+    def __init__(self, cmd_args=()):
+        self._cmd_args = cmd_args
+
+    def __call__(self, deployment_config, channel, spec_config=None):
+        bootstrap_counter.inc()
+        LOG.info("Bootstrapping %s in %s", deployment_config.name, deployment_config.namespace)
+        container = Container(
+            name="fiaas-deploy-daemon-bootstrap",
+            image=channel.metadata['image'],
+            command=["fiaas-deploy-daemon-bootstrap"] + self._cmd_args
+        )
+        pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")
+        pod_annotations = _get_pod_annotations(spec_config)
+        pod_metadata = ObjectMeta(name="fiaas-deploy-daemon-bootstrap-" +
+                                       ''.join(random.choices(string.ascii_lowercase, k=8)),
+                                  annotations=pod_annotations,
+                                  namespace=deployment_config.namespace)
+        pod = Pod(metadata=pod_metadata, spec=pod_spec)
+        pod.save()
 
 
 def _get_pod_annotations(spec_config):

--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -7,6 +7,7 @@ import random
 import string
 
 from k8s.models.common import ObjectMeta
+from k8s.models.job import JobSpec, Job
 from k8s.models.pod import Container, PodSpec, PodTemplateSpec, Pod
 from prometheus_client import Counter
 

--- a/fiaas_skipper/deploy/crd/bootstrap.py
+++ b/fiaas_skipper/deploy/crd/bootstrap.py
@@ -8,12 +8,12 @@ from k8s.models.common import ObjectMeta
 from k8s.models.custom_resource_definition import CustomResourceDefinition, CustomResourceDefinitionSpec, \
     CustomResourceDefinitionNames
 
-from ...deploy.bootstrap import BatchJobsBootstrapper
+from ...deploy.bootstrap import BarePodBootstrapper
 
 LOG = logging.getLogger(__name__)
 
 
-class CrdBootstrapper(BatchJobsBootstrapper):
+class CrdBootstrapper(BarePodBootstrapper):
     def __init__(self):
         def _create(kind, plural, short_names, group):
             name = "%s.%s" % (plural, group)

--- a/fiaas_skipper/deploy/crd/bootstrap.py
+++ b/fiaas_skipper/deploy/crd/bootstrap.py
@@ -8,12 +8,12 @@ from k8s.models.common import ObjectMeta
 from k8s.models.custom_resource_definition import CustomResourceDefinition, CustomResourceDefinitionSpec, \
     CustomResourceDefinitionNames
 
-from ...deploy.bootstrap import Bootstrapper
+from ...deploy.bootstrap import BatchJobsBootstrapper
 
 LOG = logging.getLogger(__name__)
 
 
-class CrdBootstrapper(Bootstrapper):
+class CrdBootstrapper(BatchJobsBootstrapper):
     def __init__(self):
         def _create(kind, plural, short_names, group):
             name = "%s.%s" % (plural, group)

--- a/fiaas_skipper/deploy/tpr/bootstrap.py
+++ b/fiaas_skipper/deploy/tpr/bootstrap.py
@@ -7,12 +7,12 @@ import logging
 from k8s.models.common import ObjectMeta
 from k8s.models.third_party_resource import ThirdPartyResource, APIVersion
 
-from ...deploy.bootstrap import Bootstrapper
+from ...deploy.bootstrap import BarePodBootstrapper
 
 LOG = logging.getLogger(__name__)
 
 
-class TprBootstrapper(Bootstrapper):
+class TprBootstrapper(BarePodBootstrapper):
     def __init__(self):
         def bootstrap():
             metadata = ObjectMeta(name="paasbeta-application.schibsted.io")

--- a/helm/fiaas-skipper/templates/config_map.yaml
+++ b/helm/fiaas-skipper/templates/config_map.yaml
@@ -13,5 +13,6 @@ data:
     {{with .Values.TPR}}enable-tpr-support: {{.}}{{end}}
     {{with .Values.CRD}}enable-crd-support: {{.}}{{end}}
     {{with .Values.baseurl}}baseurl: {{.}}{{end}}
+    {{with .Values.debug}}debug: true{{end}}
   fiaas.yaml: |
 {{ .Files.Get "fiaas.yaml" | indent 4 }}


### PR DESCRIPTION
In order to avoid problems with batch jobs without backoff policies on 1.6 perhaps this could be explored as an alternative approach. This would potentially requires additionally cleaning up bootstrapping pods. 