### PR TITLE
Refactor some code around deployment config and status

### DIFF
--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -2,16 +2,17 @@
 # -*- coding: utf-8
 from __future__ import absolute_import
 
-import logging
 import json
-
+import logging
 import os
+
 import yaml
 from k8s import config as k8s_config
 
 from .config import Configuration
-from .deploy import Cluster, CrdDeployer, TprDeployer, ReleaseChannelFactory, CrdBootstrapper, TprBootstrapper
+from .deploy import CrdDeployer, TprDeployer, ReleaseChannelFactory, CrdBootstrapper, TprBootstrapper
 from .deploy.channel import FakeReleaseChannelFactory
+from .deploy.cluster import Cluster
 from .logsetup import init_logging
 from .web import create_webapp
 

--- a/fiaas_skipper/deploy/__init__.py
+++ b/fiaas_skipper/deploy/__init__.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 
 from .channel import ReleaseChannelFactory
 from .crd import CrdDeployer, CrdBootstrapper
-from .deploy import Cluster, DeploymentConfigStatus
 from .tpr import TprDeployer, TprBootstrapper
 
-__all__ = ["TprDeployer", "TprBootstrapper", "CrdDeployer", "CrdBootstrapper", "Cluster",
-           "ReleaseChannelFactory", "DeploymentConfigStatus"]
+__all__ = ["TprDeployer", "TprBootstrapper", "CrdDeployer", "CrdBootstrapper", "ReleaseChannelFactory"]

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -57,7 +57,7 @@ class Cluster(object):
             except Exception as e:
                 LOG.warn(e, exc_info=True)
                 status = 'ERROR'
-                description = e.message
+                description = str(e)
             res.append(DeploymentConfigStatus(name=name,
                                               namespace=c.metadata.namespace,
                                               status=status,

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import logging
+
+from k8s.client import NotFound
+from k8s.models.configmap import ConfigMap
+from k8s.models.deployment import Deployment
+
+LOG = logging.getLogger(__name__)
+
+
+class DeploymentConfig(object):
+    def __init__(self, name, namespace, tag):
+        self.name = name
+        self.namespace = namespace
+        self.tag = tag
+
+
+class DeploymentConfigStatus(object):
+    def __init__(self, name, namespace, status, description):
+        self.name = name
+        self.namespace = namespace
+        self.status = status
+        self.description = description
+
+
+class Cluster(object):
+    @staticmethod
+    def find_deployment_configs(name):
+        res = []
+        configmaps = ConfigMap.find(name, namespace=None)
+        for c in configmaps:
+            tag = c.data['tag'] if 'tag' in c.data else 'stable'
+            res.append(DeploymentConfig(name=name, namespace=c.metadata.namespace, tag=tag))
+        return res
+
+    @staticmethod
+    def find_deployment_config_statuses(name):
+        res = []
+        configmaps = ConfigMap.find(name, namespace=None)
+        for c in configmaps:
+            description = None
+            try:
+                dep = Deployment.get(name=name, namespace=c.metadata.namespace)
+                if dep.status.availableReplicas >= dep.spec.replicas:
+                    status = 'SUCCESS'
+                else:
+                    status = 'FAILED'
+                    description = 'Available replicas does not match the number of replicas in spec'
+            except NotFound:
+                status = 'NOT FOUND'
+                description = 'No deployment found for given namespace - needs bootstrapping'
+            except TypeError:
+                status = 'UNAVAILABLE'
+                pass
+            except Exception as e:
+                LOG.warn(e, exc_info=True)
+                status = 'ERROR'
+                description = e.message
+            res.append(DeploymentConfigStatus(name=name,
+                                              namespace=c.metadata.namespace,
+                                              status=status,
+                                              description=description))
+        return res

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -9,7 +9,6 @@ import pkg_resources
 import yaml
 from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
-from k8s.models.configmap import ConfigMap
 from k8s.models.deployment import Deployment
 from prometheus_client import Counter, Gauge
 
@@ -61,61 +60,6 @@ class Deployer(object):
         return ObjectMeta(name=deployment_config.name,
                           namespace=deployment_config.namespace,
                           labels=labels)
-
-
-class DeploymentConfig(object):
-    def __init__(self, name, namespace, tag):
-        self.name = name
-        self.namespace = namespace
-        self.tag = tag
-
-
-class DeploymentConfigStatus(object):
-    def __init__(self, name, namespace, status, description):
-        self.name = name
-        self.namespace = namespace
-        self.status = status
-        self.description = description
-
-
-class Cluster(object):
-    @staticmethod
-    def find_deployment_configs(name):
-        res = []
-        configmaps = ConfigMap.find(name, namespace=None)
-        for c in configmaps:
-            tag = c.data['tag'] if 'tag' in c.data else 'stable'
-            res.append(DeploymentConfig(name=NAME, namespace=c.metadata.namespace, tag=tag))
-        return res
-
-    @staticmethod
-    def find_deployment_config_statuses(name):
-        res = []
-        configmaps = ConfigMap.find(name, namespace=None)
-        for c in configmaps:
-            description = None
-            try:
-                dep = Deployment.get(name=name, namespace=c.metadata.namespace)
-                if dep.status.availableReplicas >= dep.spec.replicas:
-                    status = 'SUCCESS'
-                else:
-                    status = 'FAILED'
-                    description = 'Available replicas does not match the number of replicas in spec'
-            except NotFound:
-                status = 'NOT FOUND'
-                description = 'No deployment found for given namespace - needs bootstrapping'
-            except TypeError:
-                status = 'UNAVAILABLE'
-                pass
-            except Exception as e:
-                LOG.warn(e, exc_info=True)
-                status = 'ERROR'
-                description = e.message
-            res.append(DeploymentConfigStatus(name=name,
-                                              namespace=c.metadata.namespace,
-                                              status=status,
-                                              description=description))
-        return res
 
 
 def requires_bootstrap(deployment_config):

--- a/fiaas_skipper/web/api.py
+++ b/fiaas_skipper/web/api.py
@@ -8,7 +8,7 @@ import threading
 
 from flask import Blueprint, make_response, request
 
-from ..deploy import DeploymentConfigStatus
+from ..deploy.cluster import DeploymentConfigStatus
 from ..web import request_histogram
 
 LOG = logging.getLogger(__name__)

--- a/tests/fiaas_skipper/deploy/crd/test_deployer.py
+++ b/tests/fiaas_skipper/deploy/crd/test_deployer.py
@@ -5,8 +5,8 @@ import pytest
 
 from fiaas_skipper import CrdDeployer
 from fiaas_skipper.deploy.channel import ReleaseChannel
+from fiaas_skipper.deploy.cluster import DeploymentConfig
 from fiaas_skipper.deploy.crd.types import FiaasApplicationSpec
-from fiaas_skipper.deploy.deploy import DeploymentConfig
 
 
 class TestCrdDeployer(object):

--- a/tests/fiaas_skipper/deploy/test_cluster.py
+++ b/tests/fiaas_skipper/deploy/test_cluster.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import pytest
+from k8s.client import NotFound
+from k8s.models.common import ObjectMeta
+from k8s.models.configmap import ConfigMap
+from k8s.models.deployment import Deployment, DeploymentStatus, DeploymentSpec
+from mock import mock
+
+from fiaas_skipper.deploy.cluster import Cluster
+
+NAME = "deployment_target"
+
+
+def _create_configmap(namespace, tag=None):
+    metadata = ObjectMeta(name=NAME, namespace=namespace)
+    data = {}
+    if tag:
+        data["tag"] = tag
+    return ConfigMap(metadata=metadata, data=data)
+
+
+def _create_deployment(available_replicas=1):
+    spec = DeploymentSpec(replicas=1)
+    status = DeploymentStatus(availableReplicas=available_replicas)
+    return Deployment(spec=spec, status=status)
+
+
+def _assert_deployment_config(result, namespace, tag):
+    assert namespace == result.namespace
+    assert tag == result.tag
+
+
+def _assert_deployment_config_status(deployment_config_status, namespace, status):
+    assert namespace == deployment_config_status.namespace
+    assert status == deployment_config_status.status
+
+
+class TestCluster(object):
+    @pytest.fixture
+    def config_map_find(self):
+        with mock.patch("k8s.models.configmap.ConfigMap.find") as finder:
+            finder.return_value = (
+                _create_configmap("ns1", "stable"),
+                _create_configmap("ns2", "latest"),
+                _create_configmap("ns3"),
+                _create_configmap("ns4", "latest"),
+                _create_configmap("ns5", "stable"),
+            )
+            yield finder
+
+    @pytest.fixture
+    def deployment_get(self):
+        with mock.patch("k8s.models.deployment.Deployment.get") as getter:
+            yield getter
+
+    @pytest.mark.usefixtures("config_map_find")
+    def test_finds_deployment_configs(self):
+        cluster = Cluster()
+        results = cluster.find_deployment_configs(NAME)
+
+        assert len(results) == 5
+        _assert_deployment_config(results[0], "ns1", "stable")
+        _assert_deployment_config(results[1], "ns2", "latest")
+        _assert_deployment_config(results[2], "ns3", "stable")
+
+    @pytest.mark.usefixtures("config_map_find")
+    def test_finds_deployment_config_status(self, deployment_get):
+        deployment_get.side_effect = (
+            _create_deployment(),
+            _create_deployment(0),
+            NotFound,
+            TypeError,
+            Exception("error"),
+        )
+
+        cluster = Cluster()
+        results = cluster.find_deployment_config_statuses(NAME)
+
+        assert len(results) == 5
+        _assert_deployment_config_status(results[0], "ns1", "SUCCESS")
+        _assert_deployment_config_status(results[1], "ns2", "FAILED")
+        _assert_deployment_config_status(results[2], "ns3", "NOT FOUND")
+        _assert_deployment_config_status(results[3], "ns4", "UNAVAILABLE")
+        _assert_deployment_config_status(results[4], "ns5", "ERROR")

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -3,7 +3,8 @@
 import mock
 import pytest
 
-from fiaas_skipper.deploy.deploy import Deployer, DeploymentConfig
+from fiaas_skipper.deploy.cluster import DeploymentConfig
+from fiaas_skipper.deploy.deploy import Deployer
 
 
 class TestDeployer(object):

--- a/tests/fiaas_skipper/deploy/tpr/test_deployer.py
+++ b/tests/fiaas_skipper/deploy/tpr/test_deployer.py
@@ -5,8 +5,8 @@ import pytest
 
 from fiaas_skipper import TprDeployer
 from fiaas_skipper.deploy.channel import ReleaseChannel
+from fiaas_skipper.deploy.cluster import DeploymentConfig
 from fiaas_skipper.deploy.tpr.types import PaasbetaApplicationSpec
-from fiaas_skipper.deploy.deploy import DeploymentConfig
 
 
 class TestTprDeployer(object):

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -43,13 +43,15 @@ class TestApi(object):
 
     def test_status(self, app, cluster):
         cluster.find_deployment_config_statuses.return_value = [DeploymentConfigStatus(name='fiaas-deploy-daemon',
-                                                    namespace='default',
-                                                    status='OK',
-                                                    description='All good')]
+                                                                                       namespace='default',
+                                                                                       status='OK',
+                                                                                       description='All good')]
         response = app.get('/api/status')
         cluster.find_deployment_config_statuses.assert_called_once_with('fiaas-deploy-daemon')
         assert response.status_code == 200
-        assert json.loads(response.data) == [{"status": "OK", "namespace": "default", "name": "fiaas-deploy-daemon", "description": "All good"}]
+        assert json.loads(response.data) == [
+            {"status": "OK", "namespace": "default", "name": "fiaas-deploy-daemon", "description": "All good"}
+        ]
 
     def test_deploy(self, app):
         with patch('fiaas_skipper.deploy.deploy.Deployer.deploy') as mock:

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -8,8 +8,8 @@ import pytest
 from flask import Flask
 from mock import patch, Mock
 
-from fiaas_skipper.deploy import Cluster
-from fiaas_skipper.deploy.deploy import DeploymentConfigStatus, Deployer
+from fiaas_skipper.deploy.cluster import DeploymentConfigStatus, Cluster
+from fiaas_skipper.deploy.deploy import Deployer
 from fiaas_skipper.web.api import api
 
 

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 from flask import Flask
-from mock import patch, Mock
+from mock import patch, Mock, create_autospec
 
 from fiaas_skipper.deploy.cluster import DeploymentConfigStatus, Cluster
 from fiaas_skipper.deploy.deploy import Deployer
@@ -24,7 +24,7 @@ class TestApi(object):
 
     @pytest.fixture
     def cluster(self):
-        return Cluster()
+        return create_autospec(Cluster(), spec_set=True, instance=True)
 
     @pytest.fixture
     def app(self, cluster, deployer):
@@ -34,24 +34,22 @@ class TestApi(object):
         app.register_blueprint(api)
         return app.test_client()
 
-    def test_empty_status(self, app):
-        with patch('fiaas_skipper.deploy.Cluster.find_deployment_config_statuses') as mock:
-            mock.return_value = []
-            response = app.get('/api/status')
-            assert mock.call_args('fiaas-deploy-daemon')
-            assert response.status_code == 200
-            assert json.loads(response.data) == []
+    def test_empty_status(self, app, cluster):
+        cluster.find_deployment_config_statuses.return_value = []
+        response = app.get('/api/status')
+        cluster.find_deployment_config_statuses.assert_called_once_with('fiaas-deploy-daemon')
+        assert response.status_code == 200
+        assert json.loads(response.data) == []
 
-    def test_status(self, app):
-        with patch('fiaas_skipper.deploy.Cluster.find_deployment_config_statuses') as mock:
-            mock.return_value = [DeploymentConfigStatus(name='fiaas-deploy-daemon',
-                                                        namespace='default',
-                                                        status='OK',
-                                                        description='All good')]
-            response = app.get('/api/status')
-            assert mock.call_args('fiaas-deploy-daemon')
-            assert response.status_code == 200
-            assert json.loads(response.data) == [{"status": "OK", "namespace": "default", "name": "fiaas-deploy-daemon", "description": "All good"}]
+    def test_status(self, app, cluster):
+        cluster.find_deployment_config_statuses.return_value = [DeploymentConfigStatus(name='fiaas-deploy-daemon',
+                                                    namespace='default',
+                                                    status='OK',
+                                                    description='All good')]
+        response = app.get('/api/status')
+        cluster.find_deployment_config_statuses.assert_called_once_with('fiaas-deploy-daemon')
+        assert response.status_code == 200
+        assert json.loads(response.data) == [{"status": "OK", "namespace": "default", "name": "fiaas-deploy-daemon", "description": "All good"}]
 
     def test_deploy(self, app):
         with patch('fiaas_skipper.deploy.deploy.Deployer.deploy') as mock:


### PR DESCRIPTION
Hopefully making the code a bit more efficient and readable. We now fetch all deployments matching the wanted name, instead of fetching them one by one. This should be significantly faster.
