### PR TITLE
 Adjust content security policy and get rid of inline scripts/css

### DIFF
--- a/fiaas_skipper/web/__init__.py
+++ b/fiaas_skipper/web/__init__.py
@@ -12,7 +12,7 @@ PLATFORM_COLLECTOR.collect()
 request_histogram = Histogram("web_request_latency", "Request latency in seconds", ["page"])
 
 SELF = "'self'"
-UNSAFE_INLINE = "'unsafe-inline'"
+NONE = "'none'"
 
 
 def _connect_signals():
@@ -34,7 +34,7 @@ def create_webapp(deployer, cluster):
     from .nav import nav
     app = Flask(__name__)
     # TODO: These options are like this because we haven't set up TLS
-    csp = {'default-src': SELF, 'script-src': [SELF, UNSAFE_INLINE], 'style-src': [SELF, UNSAFE_INLINE]}
+    csp = {'default-src': SELF, 'script-src': [SELF], 'style-src': [SELF], 'object-src': [NONE]}
     Talisman(app, frame_options=DENY, force_https=False, strict_transport_security=False,
              content_security_policy=csp)
     Bootstrap(app)

--- a/fiaas_skipper/web/__init__.py
+++ b/fiaas_skipper/web/__init__.py
@@ -12,6 +12,7 @@ PLATFORM_COLLECTOR.collect()
 request_histogram = Histogram("web_request_latency", "Request latency in seconds", ["page"])
 
 SELF = "'self'"
+UNSAFE_INLINE = "'unsafe-inline'"
 
 
 def _connect_signals():
@@ -33,9 +34,9 @@ def create_webapp(deployer, cluster):
     from .nav import nav
     app = Flask(__name__)
     # TODO: These options are like this because we haven't set up TLS
-    csp = {'default-src': SELF, 'script-src': [SELF], 'style-src': [SELF]}
+    csp = {'default-src': SELF, 'script-src': [SELF, UNSAFE_INLINE], 'style-src': [SELF, UNSAFE_INLINE]}
     Talisman(app, frame_options=DENY, force_https=False, strict_transport_security=False,
-             content_security_policy=csp, content_security_policy_nonce_in=['script-src'])
+             content_security_policy=csp)
     Bootstrap(app)
     app.config['BOOTSTRAP_SERVE_LOCAL'] = True
     api.cluster = cluster

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -1,58 +1,58 @@
-  function getStatus() {
+function getStatus() {
+  $.ajax({
+    type: "GET",
+    url: "/api/status",
+    success: function(data) {
+      var json = $.parseJSON(data);
+      console.log(json);
+      var statusmap = {
+       "SUCCESS": "success",
+       "UNKNOWN": "warning",
+       "UNAVAILABLE": "warning",
+       "ERROR": "danger"
+      };
+      $("#tbody").empty();
+      $.each(json, function (index, item) {
+           var eachrow = "<tr class=\"" + statusmap[item.status] + "\">"
+                       + "<th scope=\"row\">" + item.namespace + "</td>"
+                       + "<td>" + item.status + "</td>"
+                       + "<td>" + [item.description].join('') + "</td>"
+                       + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"
+                       + "</tr>";
+           $('#tbody').append(eachrow);
+       });
+       $(".btnDeploy").each(function(){
+           var $this = $(this);
+           $this.click(function(){
+               $.ajax({
+                   type: "POST",
+                   contentType: "application/json",
+                   url: "/api/deploy",
+                   data: "{\"namespaces\": [\"" + $(this).data('namespace') + "\"]}",
+                   success: function(data) {
+                       alert("Deployment to " + $this.data('namespace') + " performed successfully");
+                   }
+               });
+           });
+       });
+    }
+  });
+  window.setTimeout(function() { getStatus() }, 180000);
+}
+
+function onStatusPageLoad() {
+  console.log( "starting periodically fetching status of namespaces" );
+  getStatus();
+}
+
+function onDeployPageLoad() {
+  $("#btnSubmit").click(function(){
     $.ajax({
-      type: "GET",
-      url: "/api/status",
+      type: "POST",
+      url: "/api/deploy",
       success: function(data) {
-        var json = $.parseJSON(data);
-        console.log(json);
-        var statusmap = {
-         "SUCCESS": "success",
-         "UNKNOWN": "warning",
-         "UNAVAILABLE": "warning",
-         "ERROR": "danger"
-        };
-        $("#tbody").empty();
-        $.each(json, function (index, item) {
-             var eachrow = "<tr class=\"" + statusmap[item.status] + "\">"
-                         + "<th scope=\"row\">" + item.namespace + "</td>"
-                         + "<td>" + item.status + "</td>"
-                         + "<td>" + [item.description].join('') + "</td>"
-                         + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"
-                         + "</tr>";
-             $('#tbody').append(eachrow);
-         });
-         $(".btnDeploy").each(function(){
-             var $this = $(this);
-             $this.click(function(){
-                 $.ajax({
-                     type: "POST",
-                     contentType: "application/json",
-                     url: "/api/deploy",
-                     data: "{\"namespaces\": [\"" + $(this).data('namespace') + "\"]}",
-                     success: function(data) {
-                         alert("Deployment to " + $this.data('namespace') + " performed successfully");
-                     }
-                 });
-             });
-         });
+        alert("Deployment performed successfully");
       }
     });
-    window.setTimeout(function() { getStatus() }, 180000);
-  }
-
-  function onStatusPageLoad() {
-    console.log( "starting periodically fetching status of namespaces" );
-    getStatus();
-  }
-
-    function onDeployPageLoad() {
-      $("#btnSubmit").click(function(){
-        $.ajax({
-          type: "POST",
-          url: "/api/deploy",
-          success: function(data) {
-            alert("Deployment performed successfully");
-          }
-        });
-      });
-    }
+  });
+}

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -4,7 +4,6 @@ function getStatus() {
     url: "/api/status",
     success: function(data) {
       var json = $.parseJSON(data);
-      console.log(json);
       var statusmap = {
        "SUCCESS": "success",
        "UNKNOWN": "warning",
@@ -41,7 +40,6 @@ function getStatus() {
 }
 
 function onStatusPageLoad() {
-  console.log( "starting periodically fetching status of namespaces" );
   getStatus();
 }
 

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -29,7 +29,7 @@ function getStatus() {
                    url: "/api/deploy",
                    data: "{\"namespaces\": [\"" + $(this).data('namespace') + "\"]}",
                    success: function(data) {
-                       alert("Deployment to " + $this.data('namespace') + " scheduled successfully");
+                       alert("Deployment to " + $this.data("namespace") + " scheduled successfully");
                    }
                });
            });
@@ -56,9 +56,9 @@ function onDeployPageLoad() {
 }
 
 $().ready(function() {
-  if ($('body').attr('class') == "deploy") {
+  if ($("body").attr("class") === "deploy") {
     onDeployPageLoad();
-  } else if ($('body').attr('class') == "status") {
+  } else if ($("body").attr("class") === "status") {
     onStatusPageLoad();
   }
 });

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -29,7 +29,7 @@ function getStatus() {
                    url: "/api/deploy",
                    data: "{\"namespaces\": [\"" + $(this).data('namespace') + "\"]}",
                    success: function(data) {
-                       alert("Deployment to " + $this.data('namespace') + " performed successfully");
+                       alert("Deployment to " + $this.data('namespace') + " scheduled successfully");
                    }
                });
            });
@@ -49,7 +49,7 @@ function onDeployPageLoad() {
       type: "POST",
       url: "/api/deploy",
       success: function(data) {
-        alert("Deployment performed successfully");
+        alert("Deployment scheduled successfully");
       }
     });
   });

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -54,3 +54,11 @@ function onDeployPageLoad() {
     });
   });
 }
+
+$().ready(function() {
+  if ($('body').attr('class') == "deploy") {
+    onDeployPageLoad();
+  } else if ($('body').attr('class') == "status") {
+    onStatusPageLoad();
+  }
+});

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -40,6 +40,19 @@
     window.setTimeout(function() { getStatus() }, 180000);
   }
 
-  $().ready(function() {
+  function onStatusPageLoad() {
+    console.log( "starting periodically fetching status of namespaces" );
     getStatus();
-  });
+  }
+
+    function onDeployPageLoad() {
+      $("#btnSubmit").click(function(){
+        $.ajax({
+          type: "POST",
+          url: "/api/deploy",
+          success: function(data) {
+            alert("Deployment performed successfully");
+          }
+        });
+      });
+    }

--- a/fiaas_skipper/web/templates/deploy.html
+++ b/fiaas_skipper/web/templates/deploy.html
@@ -1,5 +1,5 @@
 {%- extends "base.html" %}
-{% block body_attribs %} class="deploy" onLoad="onDeployPageLoad"{% endblock %}
+{% block body_attribs %} class="deploy"{% endblock %}
 
 {% block content %}
   <div class="container">

--- a/fiaas_skipper/web/templates/deploy.html
+++ b/fiaas_skipper/web/templates/deploy.html
@@ -7,7 +7,7 @@
     <div class="jumbotron">
       <p>Note: This will deploy FIAAS deploy daemon to all FIAAS-enabled namespaces in the cluster.</p>
     </div>
-    <div class="center-block" style="max-width: 400px">
+    <div class="center-block">
       <button id="btnSubmit" class="btn btn-lg btn-primary btn-block" type="submit">Deploy</button>
     </div>
   </div>

--- a/fiaas_skipper/web/templates/deploy.html
+++ b/fiaas_skipper/web/templates/deploy.html
@@ -1,5 +1,5 @@
 {%- extends "base.html" %}
-
+{% block body_attribs %} class="deploy" onLoad="onDeployPageLoad"{% endblock %}
 
 {% block content %}
   <div class="container">
@@ -15,17 +15,5 @@
 
 {% block scripts %}
   {{super()}}
-  <script type="text/javascript">
-    $().ready(function() {
-      $("#btnSubmit").click(function(){
-        $.ajax({
-          type: "POST",
-          url: "/api/deploy",
-          success: function(data) {
-            alert("Deployment performed successfully");
-          }
-        });
-      });
-    });
-  </script>
+  <script src="{{url_for('static', filename='skipper.js')}}"></script>
 {% endblock %}

--- a/fiaas_skipper/web/templates/status.html
+++ b/fiaas_skipper/web/templates/status.html
@@ -1,5 +1,6 @@
 {%- extends "base.html" %}
 {% import "bootstrap/utils.html" as utils %}
+{% block body_attribs %} class="status" onLoad="onStatusPageLoad()"{% endblock %}
 
 {% block content %}
   <div class="container">
@@ -32,5 +33,5 @@
 
 {% block scripts %}
   {{super()}}
-  <script type="text/javascript" src="{{url_for('static', filename='skipper.js')}}" nonce="{{ csp_nonce() }}"/>
+  <script src="{{url_for('static', filename='skipper.js')}}"></script>
 {% endblock %}

--- a/fiaas_skipper/web/templates/status.html
+++ b/fiaas_skipper/web/templates/status.html
@@ -1,6 +1,6 @@
 {%- extends "base.html" %}
 {% import "bootstrap/utils.html" as utils %}
-{% block body_attribs %} class="status" onLoad="onStatusPageLoad()"{% endblock %}
+{% block body_attribs %} class="status"{% endblock %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
There were some stray inline scripts and css that were prevented from running which have now been extracted to external js files that allow them to be run. The csp policy was adjusted to include settings that were missing. Added on page load mechanism to execute selective document ready blocks previously included on each template.