### PR TITLE
Auto-update when new versions are available

### DIFF
--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -46,6 +46,11 @@ def _load_spec_config(spec_file):
         return yaml.safe_load(stream)
 
 
+def _read_file(spec_file):
+    with open(spec_file) as f:
+        return f.read()
+
+
 def main():
     cfg = Configuration()
     init_logging(cfg)
@@ -56,7 +61,8 @@ def main():
         cluster = Cluster()
         if cfg.release_channel_metadata:
             log.debug("!!Using hardcoded release channel metadata {!r}".format(cfg.release_channel_metadata))
-            release_channel_factory = FakeReleaseChannelFactory(json.loads(cfg.release_channel_metadata))
+            spec = _read_file(cfg.release_channel_metadata_spec)
+            release_channel_factory = FakeReleaseChannelFactory(json.loads(cfg.release_channel_metadata), spec)
         else:
             release_channel_factory = ReleaseChannelFactory(cfg.baseurl)
         spec_config_extension = None

--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from k8s import config as k8s_config
 
+from fiaas_skipper.update import AutoUpdater
 from .config import Configuration
 from .deploy import CrdDeployer, TprDeployer, ReleaseChannelFactory, CrdBootstrapper, TprBootstrapper
 from .deploy.channel import FakeReleaseChannelFactory
@@ -72,6 +73,12 @@ def main():
         elif cfg.enable_tpr_support:
             deployer = TprDeployer(cluster=cluster, release_channel_factory=release_channel_factory,
                                    bootstrap=TprBootstrapper(), spec_config_extension=spec_config_extension)
+        if not cfg.disable_autoupdate:
+            updater = AutoUpdater(release_channel_factory=release_channel_factory, deployer=deployer)
+            updater.daemon = True
+            updater.start()
+        else:
+            log.debug("Auto updates disabled")
         webapp = create_webapp(deployer, cluster, release_channel_factory)
         Main(webapp=webapp, config=cfg).run()
     except BaseException:

--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -48,6 +48,8 @@ class Configuration(Namespace):
         parser.add_argument("--spec-file-override",
                             help="File containing overrides of values in release channel spec file.",
                             default=DEFAULT_OVERRIDE_SPEC_FILE)
+        parser.add_argument("--disable-autoupdate", help="Disable auto updating of fiaas-deploy-daemon.",
+                            action="store_true")
         api_parser = parser.add_argument_group("API server")
         api_parser.add_argument("--api-server", help="Address of the api-server to use (IP or name)",
                                 default="https://kubernetes.default.svc.cluster.local")

--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -45,6 +45,8 @@ class Configuration(Namespace):
                             default="http://fiaas-release.delivery-pro.schibsted.io")
         parser.add_argument("--release-channel-metadata",
                             help="Provide hardcoded release channel metadata (Used for debugging purposes).")
+        parser.add_argument("--release-channel-metadata-spec",
+                            help="Provide hardcoded spec file (Used for debugging purposes).")
         parser.add_argument("--spec-file-override",
                             help="File containing overrides of values in release channel spec file.",
                             default=DEFAULT_OVERRIDE_SPEC_FILE)

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
-
 import logging
 
 from k8s.models.configmap import ConfigMap
-from k8s.models.deployment import Deployment
 
 LOG = logging.getLogger(__name__)
 
@@ -16,15 +14,6 @@ class DeploymentConfig(object):
         self.tag = tag
 
 
-class DeploymentConfigStatus(object):
-    def __init__(self, name, namespace, status, description, version):
-        self.name = name
-        self.namespace = namespace
-        self.status = status
-        self.description = description
-        self.version = version
-
-
 class Cluster(object):
     @staticmethod
     def find_deployment_configs(name):
@@ -34,41 +23,3 @@ class Cluster(object):
             tag = c.data['tag'] if 'tag' in c.data else 'stable'
             res.append(DeploymentConfig(name=name, namespace=c.metadata.namespace, tag=tag))
         return res
-
-    @staticmethod
-    def find_deployment_config_statuses(name):
-        try:
-            configmaps = ConfigMap.find(name, namespace=None)
-            deployments = {d.metadata.namespace: d for d in Deployment.find(name, namespace=None)}
-        except Exception:
-            LOG.exception("Unable to get configmaps or deployments from k8s")
-            return []
-        res = []
-        for c in configmaps:
-            description = None
-            version = None
-            try:
-                dep = deployments.get(c.metadata.namespace)
-                if dep is None:
-                    status = 'NOT FOUND'
-                    description = 'No deployment found for given namespace - needs bootstrapping'
-                else:
-                    version = _get_version(dep)
-                    if dep.status.availableReplicas >= dep.spec.replicas:
-                        status = 'SUCCESS'
-                    else:
-                        status = 'FAILED'
-                        description = 'Available replicas does not match the number of replicas in spec'
-            except TypeError:
-                status = 'UNAVAILABLE'
-                description = 'Unable to read number of available replicas from k8s server'
-            res.append(DeploymentConfigStatus(name=name,
-                                              namespace=c.metadata.namespace,
-                                              status=status,
-                                              description=description,
-                                              version=version))
-        return res
-
-
-def _get_version(dep):
-    return dep.spec.template.spec.containers[0].image.split(":")[-1]

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
+import collections
 import logging
 
 from k8s.models.configmap import ConfigMap
 
 LOG = logging.getLogger(__name__)
 
-
-class DeploymentConfig(object):
-    def __init__(self, name, namespace, tag):
-        self.name = name
-        self.namespace = namespace
-        self.tag = tag
+DeploymentConfig = collections.namedtuple('DeploymentConfig', ['name', 'namespace', 'tag'])
 
 
 class Cluster(object):
     @staticmethod
-    def find_deployment_configs(name):
+    def find_deployment_configs(name, namespace=None):
         res = []
-        configmaps = ConfigMap.find(name, namespace=None)
+        configmaps = ConfigMap.find(name, namespace)
         for c in configmaps:
             tag = c.data['tag'] if 'tag' in c.data else 'stable'
             res.append(DeploymentConfig(name=name, namespace=c.metadata.namespace, tag=tag))

--- a/fiaas_skipper/deploy/crd/deployer.py
+++ b/fiaas_skipper/deploy/crd/deployer.py
@@ -21,3 +21,6 @@ class CrdDeployer(Deployer):
 
     def _create_application_spec(self, name, image, spec_config):
         return FiaasApplicationSpec(application=name, image=image, config=spec_config)
+
+    def _applications(self, name):
+        return FiaasApplication.find(name, namespace=None)

--- a/fiaas_skipper/deploy/crd/types.py
+++ b/fiaas_skipper/deploy/crd/types.py
@@ -18,6 +18,7 @@ class FiaasApplication(Model):
     class Meta:
         url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/applications/{name}"
         watch_list_url = "/apis/fiaas.schibsted.io/v1/watch/applications"
+        list_url = "/apis/fiaas.schibsted.io/v1/applications"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
     apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")

--- a/fiaas_skipper/deploy/crd/types.py
+++ b/fiaas_skipper/deploy/crd/types.py
@@ -27,13 +27,16 @@ class FiaasApplication(Model):
     spec = Field(FiaasApplicationSpec)
 
 
-class FiaasStatus(Model):
+class FiaasApplicationStatus(Model):
     class Meta:
-        url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/statuses/{name}"
+        list_url = "/apis/fiaas.schibsted.io/v1/application-statuses"
+        url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/application-statuses/{name}"
+        watch_list_url = "/apis/fiaas.schibsted.io/v1/watch/application-statuses"
+        watch_list_url_template = "/apis/fiaas.schibsted.io/v1/watch/namespaces/{namespace}/application-statuses"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
     apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
-    kind = Field(six.text_type, "Status")
+    kind = Field(six.text_type, "ApplicationStatus")
 
     metadata = Field(ObjectMeta)
     result = Field(six.text_type)

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -142,13 +142,13 @@ def _get_version(dep):
 
 def _get_status(dep, app):
     if dep is None:
-        return Status('NOT FOUND', 'No deployment found')
+        return Status('NOT_FOUND', 'No deployment found')
     if dep.spec.template.spec.containers[0].image != app.spec.image:
-        return Status('FAILED', 'Deployment does not match application version')
+        return Status('VERSION_MISMATCH', 'Deployment does not match application version')
     try:
         if dep.status.availableReplicas < dep.spec.replicas:
             return Status('FAILED', 'Available replicas does not match the number of replicas in spec')
         # TODO the k8s deployment model can be extended to include ready replicas and status
     except TypeError:
         return Status('UNAVAILABLE', 'Unable to determine available/ready replicas from k8s server')
-    return Status('SUCCESS', '')
+    return Status('OK', '')

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -144,7 +144,9 @@ def _get_version(dep):
 def _get_status(dep, app):
     if dep is None:
         return Status('NOT_FOUND', 'No deployment found')
-    if dep.spec.template.spec.containers[0].image != app.spec.image:
+    if app is None:
+        return Status('VERSION_MISMATCH', 'Application is not defined')
+    if not app or dep.spec.template.spec.containers[0].image != app.spec.image:
         return Status('VERSION_MISMATCH', 'Deployment does not match application version')
     try:
         if dep.status.availableReplicas < dep.spec.replicas:

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -26,12 +26,13 @@ Status = collections.namedtuple('Status', ['summary', 'description'])
 
 
 class DeploymentStatus(object):
-    def __init__(self, name, namespace, status, description, version):
+    def __init__(self, name, namespace, status, description, version, channel=None):
         self.name = name
         self.namespace = namespace
         self.status = status
         self.description = description
         self.version = version
+        self.channel = channel
 
 
 class Deployer(object):

--- a/fiaas_skipper/deploy/tpr/deployer.py
+++ b/fiaas_skipper/deploy/tpr/deployer.py
@@ -21,3 +21,6 @@ class TprDeployer(Deployer):
 
     def _create_paasbetaapplicationspec(self, name, image, spec_config):
         return PaasbetaApplicationSpec(application=name, image=image, config=spec_config)
+
+    def _applications(self, name):
+        return PaasbetaApplication.find(name, namespace=None)

--- a/fiaas_skipper/deploy/tpr/types.py
+++ b/fiaas_skipper/deploy/tpr/types.py
@@ -18,6 +18,7 @@ class PaasbetaApplication(Model):
     class Meta:
         url_template = "/apis/schibsted.io/v1beta/namespaces/{namespace}/paasbetaapplications/{name}"
         watch_list_url = "/apis/schibsted.io/v1beta/watch/paasbetaapplications"
+        list_url = "/apis/schibsted.io/v1beta/paasbetaapplications"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
     apiVersion = Field(six.text_type, "schibsted.io/v1beta")

--- a/fiaas_skipper/update.py
+++ b/fiaas_skipper/update.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import logging
+from threading import Thread
+
+import time
+
+LOG = logging.getLogger(__name__)
+CHECK_UPDATE_INTERVAL = 600
+TAGS = ('latest', 'stable')
+
+
+class AutoUpdater(Thread):
+    def __init__(self, release_channel_factory, deployer):
+        Thread.__init__(self)
+        self._release_channel_factory = release_channel_factory
+        self._deployer = deployer
+        self._images = {}
+
+    def check_updates(self):
+        """
+        Check if there are new versions available.
+        If there are the deployer is triggered.
+        """
+        LOG.debug("Checking for new updates")
+        found_update = False
+        for t in TAGS:
+            channel = self._release_channel_factory('fiaas-deploy-daemon', t)
+            if self._new_version_available(channel):
+                LOG.debug("Detected new update for {} ({})".format(t, channel.metadata['image']))
+                found_update = True
+            self._images[t] = channel.metadata['image']
+        if found_update:
+            # TODO perhaps this could be made smarter by inspecting namespaces
+            self._deployer.deploy()
+
+    def _new_version_available(self, channel):
+        return self._images.get(channel.tag, channel.metadata['image']) != channel.metadata['image']
+
+    def check_bootstrap(self):
+        """
+        Check if there are any namespaces that need bootstrapping.
+        If that is the case the deployer is triggered.
+        """
+        LOG.debug("Checking for namespaces that need bootstrapping")
+        need_bootstrap = [s.namespace for s in self._deployer.status() if s.status == 'NOT FOUND']
+        if need_bootstrap:
+            LOG.debug("Detected namespaces {} need bootstrapping".format(', '.join(need_bootstrap)))
+            self._deployer.deploy(namespaces=need_bootstrap)
+
+    def run(self):
+        while True:
+            self.check_bootstrap()
+            self.check_updates()
+            time.sleep(CHECK_UPDATE_INTERVAL)

--- a/fiaas_skipper/update.py
+++ b/fiaas_skipper/update.py
@@ -7,7 +7,7 @@ from threading import Thread
 import time
 
 LOG = logging.getLogger(__name__)
-CHECK_UPDATE_INTERVAL = 60
+CHECK_UPDATE_INTERVAL = 600
 
 
 class AutoUpdater(Thread):

--- a/fiaas_skipper/update.py
+++ b/fiaas_skipper/update.py
@@ -44,7 +44,7 @@ class AutoUpdater(Thread):
         If that is the case the deployer is triggered.
         """
         LOG.debug("Checking for namespaces that need bootstrapping")
-        need_bootstrap = [s.namespace for s in self._deployer.status() if s.status == 'NOT FOUND']
+        need_bootstrap = [s.namespace for s in self._deployer.status() if s.status == 'NOT_FOUND']
         if need_bootstrap:
             LOG.debug("Detected namespaces {} need bootstrapping".format(', '.join(need_bootstrap)))
             self._deployer.deploy(namespaces=need_bootstrap)

--- a/fiaas_skipper/web/api.py
+++ b/fiaas_skipper/web/api.py
@@ -8,7 +8,7 @@ import threading
 
 from flask import Blueprint, make_response, request
 
-from ..deploy.cluster import DeploymentConfigStatus
+from ..deploy.deploy import DeploymentStatus
 from ..web import request_histogram
 
 LOG = logging.getLogger(__name__)
@@ -22,12 +22,12 @@ deploy_histogram = request_histogram.labels("deploy")
 @api.route('/api/status')
 @status_histogram.time()
 def status():
-    deployment_config_statuses = api.cluster.find_deployment_config_statuses('fiaas-deploy-daemon')
-    return make_response(json.dumps(deployment_config_statuses, default=_encode), 200)
+    deployment_statuses = api.deployer.status()
+    return make_response(json.dumps(deployment_statuses, default=_encode), 200)
 
 
 def _encode(obj):
-    if isinstance(obj, DeploymentConfigStatus):
+    if isinstance(obj, DeploymentStatus):
         return obj.__dict__
     return obj
 

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -18,6 +18,7 @@ function getStatus() {
                        + "<th scope=\"row\">" + item.namespace + "</td>"
                        + "<td>" + item.status.replace(/_/g, " ") + "</td>"
                        + "<td>" + [item.description].join('') + "</td>"
+                       + "<td>" + item.channel + "</td>"
                        + "<td>" + item.version + "</td>"
                        + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"
                        + "</tr>";

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -5,16 +5,18 @@ function getStatus() {
     success: function(data) {
       var json = $.parseJSON(data);
       var statusmap = {
-       "SUCCESS": "success",
+       "OK": "success",
        "UNKNOWN": "warning",
        "UNAVAILABLE": "warning",
-       "ERROR": "danger"
+       "ERROR": "danger",
+       "FAILED": "danger",
+       "VERSION_MISMATCH": "warning"
       };
       $("#tbody").empty();
       $.each(json, function (index, item) {
            var eachrow = "<tr class=\"" + statusmap[item.status] + "\">"
                        + "<th scope=\"row\">" + item.namespace + "</td>"
-                       + "<td>" + item.status + "</td>"
+                       + "<td>" + item.status.replace(/_/g, " ") + "</td>"
                        + "<td>" + [item.description].join('') + "</td>"
                        + "<td>" + item.version + "</td>"
                        + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"

--- a/fiaas_skipper/web/templates/status.html
+++ b/fiaas_skipper/web/templates/status.html
@@ -36,6 +36,7 @@
           <th scope="col">Namespace</th>
           <th scope="col">Status</th>
           <th scope="col">Description</th>
+          <th scope="col">Channel</th>
           <th scope="col">Version</th>
         </tr>
       </thead>

--- a/tests/fiaas_skipper/deploy/test_cluster.py
+++ b/tests/fiaas_skipper/deploy/test_cluster.py
@@ -4,8 +4,6 @@
 import pytest
 from k8s.models.common import ObjectMeta
 from k8s.models.configmap import ConfigMap
-from k8s.models.deployment import Deployment, DeploymentStatus, DeploymentSpec
-from k8s.models.pod import PodTemplateSpec, PodSpec, Container
 from mock import mock
 
 from fiaas_skipper.deploy.cluster import Cluster
@@ -21,24 +19,9 @@ def _create_configmap(namespace, tag=None):
     return ConfigMap(metadata=metadata, data=data)
 
 
-def _create_deployment(available_replicas, namespace, image):
-    container = Container(image=image)
-    pod_spec = PodSpec(containers=[container])
-    pod_template_spec = PodTemplateSpec(spec=pod_spec)
-    spec = DeploymentSpec(replicas=1, template=pod_template_spec)
-    status = DeploymentStatus(availableReplicas=available_replicas)
-    metadata = ObjectMeta(name=NAME, namespace=namespace)
-    return Deployment(metadata=metadata, spec=spec, status=status)
-
-
 def _assert_deployment_config(result, namespace, tag):
     assert namespace == result.namespace
     assert tag == result.tag
-
-
-def _assert_deployment_config_status(deployment_config_status, namespace, status):
-    assert namespace == deployment_config_status.namespace
-    assert status == deployment_config_status.status
 
 
 class TestCluster(object):
@@ -54,11 +37,6 @@ class TestCluster(object):
             )
             yield finder
 
-    @pytest.fixture
-    def deployment_find(self):
-        with mock.patch("k8s.models.deployment.Deployment.find") as finder:
-            yield finder
-
     @pytest.mark.usefixtures("config_map_find")
     def test_finds_deployment_configs(self):
         cluster = Cluster()
@@ -68,21 +46,3 @@ class TestCluster(object):
         _assert_deployment_config(results[0], "ns1", "stable")
         _assert_deployment_config(results[1], "ns2", "latest")
         _assert_deployment_config(results[2], "ns3", "stable")
-
-    @pytest.mark.usefixtures("config_map_find")
-    def test_finds_deployment_config_status(self, deployment_find):
-        deployment_find.return_value = (
-            _create_deployment(1, "ns1", "image:stable"),
-            _create_deployment(0, "ns2", "image:latest"),
-            _create_deployment(None, "ns4", "image:stable"),
-        )
-
-        cluster = Cluster()
-        results = cluster.find_deployment_config_statuses(NAME)
-
-        assert len(results) == 5
-        _assert_deployment_config_status(results[0], "ns1", "SUCCESS")
-        _assert_deployment_config_status(results[1], "ns2", "FAILED")
-        _assert_deployment_config_status(results[2], "ns3", "NOT FOUND")
-        _assert_deployment_config_status(results[3], "ns4", "UNAVAILABLE")
-        _assert_deployment_config_status(results[4], "ns5", "NOT FOUND")

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -2,10 +2,46 @@
 # -*- coding: utf-8
 import mock
 import pytest
+from k8s.models.common import ObjectMeta
+from k8s.models.configmap import ConfigMap
+from k8s.models.deployment import DeploymentSpec, Deployment, DeploymentStatus
+from k8s.models.pod import Container, PodSpec, PodTemplateSpec
 
 from fiaas_skipper.deploy.channel import ReleaseChannel
 from fiaas_skipper.deploy.cluster import DeploymentConfig
+from fiaas_skipper.deploy.crd.types import FiaasApplicationSpec, FiaasApplication
 from fiaas_skipper.deploy.deploy import Deployer
+
+NAME = "deployment_target"
+
+
+def _create_configmap(namespace, tag=None):
+    metadata = ObjectMeta(name=NAME, namespace=namespace)
+    data = {}
+    if tag:
+        data["tag"] = tag
+    return ConfigMap(metadata=metadata, data=data)
+
+
+def _create_deployment(available_replicas, namespace, image):
+    container = Container(image=image)
+    pod_spec = PodSpec(containers=[container])
+    pod_template_spec = PodTemplateSpec(spec=pod_spec)
+    spec = DeploymentSpec(replicas=1, template=pod_template_spec)
+    status = DeploymentStatus(availableReplicas=available_replicas)
+    metadata = ObjectMeta(name=NAME, namespace=namespace)
+    return Deployment(metadata=metadata, spec=spec, status=status)
+
+
+def _create_application(namespace, image):
+    spec = FiaasApplicationSpec(application='fdd', image=image, config={})
+    metadata = ObjectMeta(name='fdd', namespace=namespace)
+    return FiaasApplication(metadata=metadata, spec=spec)
+
+
+def _assert_deployment_config_status(deployment_config_status, namespace, status):
+    assert namespace == deployment_config_status.namespace
+    assert status == deployment_config_status.status
 
 
 class TestDeployer(object):
@@ -30,6 +66,28 @@ class TestDeployer(object):
         )
         return channel_factory
 
+    @pytest.fixture
+    def config_map_find(self):
+        with mock.patch("k8s.models.configmap.ConfigMap.find") as finder:
+            finder.return_value = (
+                _create_configmap("ns1", "stable"),
+                _create_configmap("ns2", "latest"),
+                _create_configmap("ns3"),
+                _create_configmap("ns4", "latest"),
+                _create_configmap("ns5", "stable"),
+            )
+            yield finder
+
+    @pytest.fixture
+    def deployment_find(self):
+        with mock.patch("k8s.models.deployment.Deployment.find") as finder:
+            yield finder
+
+    @pytest.fixture
+    def application_find(self):
+        with mock.patch('fiaas_skipper.deploy.deploy.Deployer._applications') as finder:
+            yield finder
+
     def test_deploys_only_to_configured_namespaces(self, cluster, release_channel_factory):
         deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
         deployer._deploy = mock.MagicMock(name="_deploy")
@@ -41,3 +99,30 @@ class TestDeployer(object):
         deployer._deploy = mock.MagicMock(name="_deploy")
         deployer.deploy()
         assert 2 == deployer._deploy.call_count
+
+    @pytest.mark.usefixtures("config_map_find")
+    def test_deployment_statuses(self, cluster, release_channel_factory, deployment_find, application_find):
+        deployment_find.return_value = (
+            _create_deployment(1, "ns1", "image:stable"),
+            _create_deployment(0, "ns2", "image:latest"),
+            _create_deployment(None, "ns4", "image:stable"),
+            _create_deployment(1, "ns5", "image:experimental"),
+        )
+
+        application_find.return_value = (
+            _create_application("ns1", "image:stable"),
+            _create_application("ns2", "image:latest"),
+            _create_application("ns3", "image:latest"),
+            _create_application("ns4", "image:stable"),
+            _create_application("ns5", "image:stable"),
+        )
+
+        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
+        results = deployer.status()
+
+        assert len(results) == 5
+        _assert_deployment_config_status(results[0], "ns1", "OK")
+        _assert_deployment_config_status(results[1], "ns2", "FAILED")
+        _assert_deployment_config_status(results[2], "ns3", "NOT_FOUND")
+        _assert_deployment_config_status(results[3], "ns4", "UNAVAILABLE")
+        _assert_deployment_config_status(results[4], "ns5", "VERSION_MISMATCH")

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -75,6 +75,7 @@ class TestDeployer(object):
                 _create_configmap("ns3"),
                 _create_configmap("ns4", "latest"),
                 _create_configmap("ns5", "stable"),
+                _create_configmap("ns6", "stable"),
             )
             yield finder
 
@@ -107,6 +108,7 @@ class TestDeployer(object):
             _create_deployment(0, "ns2", "image:latest"),
             _create_deployment(None, "ns4", "image:stable"),
             _create_deployment(1, "ns5", "image:experimental"),
+            _create_deployment(1, "ns6", "image:stable"),
         )
 
         application_find.return_value = (
@@ -120,9 +122,10 @@ class TestDeployer(object):
         deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
         results = deployer.status()
 
-        assert len(results) == 5
+        assert len(results) == 6
         _assert_deployment_config_status(results[0], "ns1", "OK")
         _assert_deployment_config_status(results[1], "ns2", "FAILED")
         _assert_deployment_config_status(results[2], "ns3", "NOT_FOUND")
         _assert_deployment_config_status(results[3], "ns4", "UNAVAILABLE")
         _assert_deployment_config_status(results[4], "ns5", "VERSION_MISMATCH")
+        _assert_deployment_config_status(results[5], "ns6", "VERSION_MISMATCH")

--- a/tests/fiaas_skipper/test_update.py
+++ b/tests/fiaas_skipper/test_update.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+import pytest
+from mock import mock
+
+from fiaas_skipper.update import AutoUpdater, TAGS
+from fiaas_skipper.deploy.channel import ReleaseChannel
+from fiaas_skipper.deploy.deploy import DeploymentStatus, Deployer
+
+
+def _create_deployment_status(namespace, status):
+    return DeploymentStatus(name='fiaas-deploy-daemon',
+                            namespace=namespace,
+                            description=None,
+                            version=None,
+                            status=status)
+
+
+class TestAutoUpdater(object):
+    @pytest.fixture
+    def deployer(self):
+        return mock.create_autospec(Deployer)
+
+    @pytest.fixture
+    def release_channel_factory(self):
+        with mock.MagicMock(name="release_channel_factory") as factory:
+            yield factory
+
+    def test_check_updates_deploys_new_version(self, release_channel_factory, deployer):
+        release_channel_factory.side_effect = (
+            lambda name, tag: ReleaseChannel(name=name, tag=tag, metadata={'image': 'new'}, spec={}))
+        updater = AutoUpdater(release_channel_factory=release_channel_factory, deployer=deployer)
+        updater._images = dict((t, 'old') for t in TAGS)
+        updater.check_updates()
+        deployer.deploy.assert_called_once()
+        assert updater._images == dict((t, 'new') for t in TAGS)
+
+    def test_no_updates_no_deployment(self, release_channel_factory, deployer):
+        release_channel_factory.side_effect = (
+            lambda name, tag: ReleaseChannel(name=name, tag=tag, metadata={'image': 'old'}, spec={}))
+        updater = AutoUpdater(release_channel_factory=release_channel_factory, deployer=deployer)
+        updater._images = dict((t, 'old') for t in TAGS)
+        updater.check_updates()
+        deployer.deploy.assert_not_called()
+
+    def test_check_bootstrap_deploys_new_version(self, release_channel_factory, deployer):
+        deployer.status.return_value = [
+            _create_deployment_status(namespace='test1', status='NOT_FOUND'),
+            _create_deployment_status(namespace='test2', status='OK')
+        ]
+        updater = AutoUpdater(release_channel_factory=release_channel_factory, deployer=deployer)
+        updater.check_bootstrap()
+        deployer.deploy.assert_called_once_with(namespaces=['test1'])

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -47,7 +47,8 @@ class TestApi(object):
                              namespace='default',
                              status='OK',
                              description='All good',
-                             version="fiaas/fiaas-deploy-daemon:123")]
+                             version="fiaas/fiaas-deploy-daemon:123",
+                             channel="stable")]
         response = app.get('/api/status')
         assert response.status_code == 200
         assert json.loads(response.data) == [{
@@ -55,7 +56,8 @@ class TestApi(object):
             "namespace": "default",
             "name": "fiaas-deploy-daemon",
             "description": "All good",
-            "version": "fiaas/fiaas-deploy-daemon:123"
+            "version": "fiaas/fiaas-deploy-daemon:123",
+            "channel": "stable"
         }]
 
     def test_deploy(self, app):

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -6,17 +6,17 @@ import json
 
 import pytest
 from flask import Flask
-from mock import patch, Mock, create_autospec
+from mock import patch, Mock, mock
 
-from fiaas_skipper.deploy.cluster import DeploymentConfigStatus, Cluster
-from fiaas_skipper.deploy.deploy import Deployer
+from fiaas_skipper.deploy.deploy import Deployer, DeploymentStatus
 from fiaas_skipper.web.api import api
 
 
 class TestApi(object):
     @pytest.fixture
-    def deployer(self, cluster):
+    def deployer(self):
         release_channel_factory = Mock()
+        cluster = Mock()
         bootstrap = Mock()
         return Deployer(cluster=cluster,
                         release_channel_factory=release_channel_factory,
@@ -24,33 +24,31 @@ class TestApi(object):
                         deploy_interval=0)
 
     @pytest.fixture
-    def cluster(self):
-        return create_autospec(Cluster(), spec_set=True, instance=True)
-
-    @pytest.fixture
-    def app(self, cluster, deployer):
+    def app(self, deployer):
         app = Flask(__name__)
-        api.cluster = cluster
         api.deployer = deployer
         app.register_blueprint(api)
         return app.test_client()
 
-    def test_empty_status(self, app, cluster):
-        cluster.find_deployment_config_statuses.return_value = []
+    @pytest.fixture
+    def deployment_status(self):
+        with mock.patch("fiaas_skipper.deploy.deploy.Deployer.status") as status:
+            yield status
+
+    def test_empty_status(self, app, deployment_status):
+        deployment_status.return_value = []
         response = app.get('/api/status')
-        cluster.find_deployment_config_statuses.assert_called_once_with('fiaas-deploy-daemon')
         assert response.status_code == 200
         assert json.loads(response.data) == []
 
-    def test_status(self, app, cluster):
-        cluster.find_deployment_config_statuses.return_value = [
-            DeploymentConfigStatus(name='fiaas-deploy-daemon',
-                                   namespace='default',
-                                   status='OK',
-                                   description='All good',
-                                   version="fiaas/fiaas-deploy-daemon:123")]
+    def test_status(self, app, deployment_status):
+        deployment_status.return_value = [
+            DeploymentStatus(name='fiaas-deploy-daemon',
+                             namespace='default',
+                             status='OK',
+                             description='All good',
+                             version="fiaas/fiaas-deploy-daemon:123")]
         response = app.get('/api/status')
-        cluster.find_deployment_config_statuses.assert_called_once_with('fiaas-deploy-daemon')
         assert response.status_code == 200
         assert json.loads(response.data) == [{
             "status": "OK",


### PR DESCRIPTION
This adds functionality for auto updating fiaas-deploy-daemon when new versions become available.
Each namespace is inspected to see if it matches the current version and updated as needed.

Deployment statuses have been extended to detect version mismatch and application missing.