### PR TITLE
Track ongoing deployments

### DIFF
--- a/fiaas_skipper/deploy/__init__.py
+++ b/fiaas_skipper/deploy/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import
 
 from .channel import ReleaseChannelFactory
-from .crd import CrdDeployer, CrdBootstrapper
-from .tpr import TprDeployer, TprBootstrapper
+from .crd import CrdDeployer, CrdBootstrapper, CrdStatusTracker
+from .tpr import TprDeployer, TprBootstrapper, TprStatusTracker
 
-__all__ = ["TprDeployer", "TprBootstrapper", "CrdDeployer", "CrdBootstrapper", "ReleaseChannelFactory"]
+__all__ = ["TprDeployer", "TprBootstrapper", "CrdDeployer", "CrdBootstrapper", "ReleaseChannelFactory",
+           "CrdStatusTracker", "TprStatusTracker"]

--- a/fiaas_skipper/deploy/crd/__init__.py
+++ b/fiaas_skipper/deploy/crd/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import absolute_import
 
 from .bootstrap import CrdBootstrapper
-from .deployer import CrdDeployer
+from .deployer import CrdDeployer, CrdStatusTracker
 
-__all__ = ["CrdBootstrapper", "CrdDeployer"]
+__all__ = ["CrdBootstrapper", "CrdDeployer", "CrdStatusTracker"]

--- a/fiaas_skipper/deploy/crd/deployer.py
+++ b/fiaas_skipper/deploy/crd/deployer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import logging
 
 from .types import FiaasApplicationSpec, FiaasApplication
-from ..deploy import Deployer
+from ..deploy import Deployer, StatusTracker
 
 LOG = logging.getLogger(__name__)
 
@@ -22,5 +22,10 @@ class CrdDeployer(Deployer):
     def _create_application_spec(self, name, image, spec_config):
         return FiaasApplicationSpec(application=name, image=image, config=spec_config)
 
-    def _applications(self, name):
-        return FiaasApplication.find(name, namespace=None)
+    def _application(self):
+        return FiaasApplication
+
+
+class CrdStatusTracker(StatusTracker):
+    def _application(self):
+        return FiaasApplication

--- a/fiaas_skipper/deploy/tpr/__init__.py
+++ b/fiaas_skipper/deploy/tpr/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import absolute_import
 
 from .bootstrap import TprBootstrapper
-from .deployer import TprDeployer
+from .deployer import TprDeployer, TprStatusTracker
 
-__all__ = ["TprBootstrapper", "TprDeployer"]
+__all__ = ["TprBootstrapper", "TprDeployer", "TprStatusTracker"]

--- a/fiaas_skipper/deploy/tpr/deployer.py
+++ b/fiaas_skipper/deploy/tpr/deployer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import logging
 
 from .types import PaasbetaApplication, PaasbetaApplicationSpec
-from ..deploy import Deployer
+from ..deploy import Deployer, StatusTracker
 
 LOG = logging.getLogger(__name__)
 
@@ -22,5 +22,10 @@ class TprDeployer(Deployer):
     def _create_paasbetaapplicationspec(self, name, image, spec_config):
         return PaasbetaApplicationSpec(application=name, image=image, config=spec_config)
 
-    def _applications(self, name):
-        return PaasbetaApplication.find(name, namespace=None)
+    def _application(self):
+        return PaasbetaApplication
+
+
+class TprStatusTracker(StatusTracker):
+    def _application(self):
+        return PaasbetaApplication

--- a/fiaas_skipper/update.py
+++ b/fiaas_skipper/update.py
@@ -53,4 +53,5 @@ class AutoUpdater(Thread):
 
     def _update_namespaces(self, channel):
         matched = [t for t in self._deployer.status() if t.channel == channel.tag]
-        return set([s.namespace for s in matched if s.version != channel.metadata['image'].split(':')[1]])
+        return set([s.namespace for s in matched
+                    if s.version != channel.metadata['image'].split(':')[1] and s.status != 'DEPLOYING'])

--- a/fiaas_skipper/update.py
+++ b/fiaas_skipper/update.py
@@ -7,7 +7,7 @@ from threading import Thread
 import time
 
 LOG = logging.getLogger(__name__)
-CHECK_UPDATE_INTERVAL = 600
+CHECK_UPDATE_INTERVAL = 60
 
 
 class AutoUpdater(Thread):

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -36,11 +36,12 @@ function getStatus() {
                        alert("Deployment to " + $this.data("namespace") + " scheduled successfully");
                    }
                });
+               getStatus(); // refresh
            });
        });
     }
   });
-  window.setTimeout(function() { getStatus(); }, 60000);
+  window.setTimeout(function() { getStatus(); }, 5000);
 }
 
 function onStatusPageLoad() {

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -20,13 +20,14 @@ function getStatus() {
                        + "<td>" + [item.description].join('') + "</td>"
                        + "<td>" + item.channel + "</td>"
                        + "<td>" + item.version + "</td>"
-                       + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"
+                       + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\"" + ((item.status === "DEPLOYING") ? " disabled=\"disabled\"" : "") + ">Deploy</button></td>"
                        + "</tr>";
            $('#tbody').append(eachrow);
        });
        $(".btnDeploy").each(function(){
            var $this = $(this);
            $this.click(function(){
+               $this.prop("disabled", true);
                $.ajax({
                    type: "POST",
                    contentType: "application/json",

--- a/tests/fiaas_skipper/deploy/crd/test_deployer.py
+++ b/tests/fiaas_skipper/deploy/crd/test_deployer.py
@@ -8,6 +8,7 @@ from fiaas_skipper import CrdDeployer
 from fiaas_skipper.deploy.channel import ReleaseChannel
 from fiaas_skipper.deploy.cluster import DeploymentConfig
 from fiaas_skipper.deploy.crd.types import FiaasApplicationSpec
+from fiaas_skipper.deploy.deploy import StatusTracker
 
 
 class TestCrdDeployer(object):
@@ -29,8 +30,12 @@ class TestCrdDeployer(object):
                                                               spec=yaml.dump({"z": "z", "y": "1"}))
         return release_channel_factory
 
+    @pytest.fixture
+    def status(self):
+        return mock.create_autospec(StatusTracker)
+
     @mock.patch('fiaas_skipper.deploy.crd.types.FiaasApplication.get_or_create', autospec=True)
-    def test_deploy_creates_fiaas_application(self, get_or_create, cluster, release_channel_factory):
+    def test_deploy_creates_fiaas_application(self, get_or_create, cluster, release_channel_factory, status):
         app = mock.MagicMock()
         spec = mock.PropertyMock()
         type(app).spec = spec
@@ -38,7 +43,7 @@ class TestCrdDeployer(object):
         bootstrap = mock.MagicMock()
         spec_config_ext = {"x": "x", "y": "66"}
         deployer = CrdDeployer(cluster, release_channel_factory, bootstrap, spec_config_extension=spec_config_ext,
-                               deploy_interval=0)
+                               deploy_interval=0, status=status)
         deployer.deploy()
         spec.assert_called_once_with(
             FiaasApplicationSpec(application="testapp", image="image1",

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -7,10 +7,11 @@ from k8s.models.configmap import ConfigMap
 from k8s.models.deployment import DeploymentSpec, Deployment, DeploymentStatus
 from k8s.models.pod import Container, PodSpec, PodTemplateSpec
 
+from fiaas_skipper.deploy import deploy
 from fiaas_skipper.deploy.channel import ReleaseChannel
 from fiaas_skipper.deploy.cluster import DeploymentConfig
 from fiaas_skipper.deploy.crd.types import FiaasApplicationSpec, FiaasApplication
-from fiaas_skipper.deploy.deploy import Deployer
+from fiaas_skipper.deploy.deploy import Deployer, StatusTracker
 
 NAME = "deployment_target"
 
@@ -44,6 +45,10 @@ def _assert_deployment_config_status(deployment_config_status, namespace, status
     assert status == deployment_config_status.status
 
 
+def _create_deployment_status(namespace, status):
+    return deploy.DeploymentStatus(name='fdd', namespace=namespace, status=status, description='', version='xx')
+
+
 class TestDeployer(object):
     @pytest.fixture
     def cluster(self):
@@ -67,60 +72,64 @@ class TestDeployer(object):
         return channel_factory
 
     @pytest.fixture
-    def config_map_find(self):
-        with mock.patch("k8s.models.configmap.ConfigMap.find") as finder:
-            finder.return_value = (
-                _create_configmap("ns1", "stable"),
-                _create_configmap("ns2", "latest"),
-                _create_configmap("ns3"),
-                _create_configmap("ns4", "latest"),
-                _create_configmap("ns5", "stable"),
-                _create_configmap("ns6", "stable"),
-            )
-            yield finder
+    def status(self):
+        return mock.create_autospec(StatusTracker)
 
-    @pytest.fixture
-    def deployment_find(self):
-        with mock.patch("k8s.models.deployment.Deployment.find") as finder:
-            yield finder
-
-    @pytest.fixture
-    def application_find(self):
-        with mock.patch('fiaas_skipper.deploy.deploy.Deployer._applications') as finder:
-            yield finder
-
-    def test_deploys_only_to_configured_namespaces(self, cluster, release_channel_factory):
-        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
+    def test_deploys_only_to_configured_namespaces(self, cluster, release_channel_factory, status):
+        status.return_value = {'test1': _create_deployment_status(namespace='test1', status='OK')}
+        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0, status=status)
         deployer._deploy = mock.MagicMock(name="_deploy")
         deployer.deploy(namespaces=("test1",))
         deployer._deploy.assert_called_once()
 
-    def test_deploys_to_all_namespaces(self, cluster, release_channel_factory):
-        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
+    def test_deploys_to_all_namespaces(self, cluster, release_channel_factory, status):
+        status.return_value = {'test1': _create_deployment_status(namespace='test1', status='OK'),
+                               'test2': _create_deployment_status(namespace='test2', status='OK')}
+        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0, status=status)
         deployer._deploy = mock.MagicMock(name="_deploy")
         deployer.deploy()
         assert 2 == deployer._deploy.call_count
 
-    @pytest.mark.usefixtures("config_map_find")
-    def test_deployment_statuses(self, cluster, release_channel_factory, deployment_find, application_find):
-        deployment_find.return_value = (
-            _create_deployment(1, "ns1", "image:stable"),
-            _create_deployment(0, "ns2", "image:latest"),
-            _create_deployment(None, "ns4", "image:stable"),
-            _create_deployment(1, "ns5", "image:experimental"),
-            _create_deployment(1, "ns6", "image:stable"),
-        )
 
-        application_find.return_value = (
+class TestStatusTracker(object):
+    @pytest.fixture
+    def cluster(self):
+        cluster = mock.NonCallableMagicMock(name="cluster")
+        cluster.find_deployment_configs.return_value = (
+            DeploymentConfig("fdd", "ns1", "stable"),
+            DeploymentConfig("fdd", "ns2", "latest"),
+            DeploymentConfig("fdd", "ns3", "stable"),
+            DeploymentConfig("fdd", "ns4", "latest"),
+            DeploymentConfig("fdd", "ns5", "stable"),
+            DeploymentConfig("fdd", "ns6", "stable"),
+        )
+        return cluster
+
+    @pytest.fixture
+    def deployment_find(self):
+        with mock.patch("k8s.models.deployment.Deployment.find") as finder:
+            finder.return_value = (
+                _create_deployment(1, "ns1", "image:stable"),
+                _create_deployment(0, "ns2", "image:latest"),
+                _create_deployment(None, "ns4", "image:stable"),
+                _create_deployment(1, "ns5", "image:experimental"),
+                _create_deployment(1, "ns6", "image:stable"),
+            )
+            yield finder
+
+    @pytest.mark.usefixtures("deployment_find")
+    def test_deployment_statuses(self, cluster):
+        status_tracker = StatusTracker(cluster)
+        applications_find = mock.MagicMock(name="_application")
+        applications_find.find.return_value = (
             _create_application("ns1", "image:stable"),
             _create_application("ns2", "image:latest"),
             _create_application("ns3", "image:latest"),
             _create_application("ns4", "image:stable"),
             _create_application("ns5", "image:stable"),
         )
-
-        deployer = Deployer(cluster, release_channel_factory, None, deploy_interval=0)
-        results = deployer.status()
+        with mock.patch.object(status_tracker, '_application', return_value=applications_find):
+            results = status_tracker._get_status()
 
         assert len(results) == 6
         _assert_deployment_config_status(results[0], "ns1", "OK")

--- a/tests/fiaas_skipper/deploy/tpr/test_deployer.py
+++ b/tests/fiaas_skipper/deploy/tpr/test_deployer.py
@@ -7,6 +7,7 @@ import yaml
 from fiaas_skipper import TprDeployer
 from fiaas_skipper.deploy.channel import ReleaseChannel
 from fiaas_skipper.deploy.cluster import DeploymentConfig
+from fiaas_skipper.deploy.deploy import StatusTracker
 from fiaas_skipper.deploy.tpr.types import PaasbetaApplicationSpec
 
 
@@ -30,8 +31,12 @@ class TestTprDeployer(object):
             spec=yaml.dump({"z": "z"}))
         return release_channel_factory
 
+    @pytest.fixture
+    def status(self):
+        return mock.create_autospec(StatusTracker)
+
     @mock.patch('fiaas_skipper.deploy.tpr.types.PaasbetaApplication.get_or_create', autospec=True)
-    def test_deploy_creates_paasbeta_application(self, get_or_create, cluster, release_channel_factory):
+    def test_deploy_creates_paasbeta_application(self, get_or_create, cluster, release_channel_factory, status):
         app = mock.MagicMock()
         spec = mock.PropertyMock()
         type(app).spec = spec
@@ -39,7 +44,7 @@ class TestTprDeployer(object):
         bootstrap = mock.MagicMock()
         spec_config_ext = {"x": "x"}
         deployer = TprDeployer(cluster, release_channel_factory, bootstrap, spec_config_extension=spec_config_ext,
-                               deploy_interval=0)
+                               deploy_interval=0, status=status)
         deployer.deploy()
         spec.assert_called_once_with(PaasbetaApplicationSpec(
             application="testapp",


### PR DESCRIPTION
This will set a flag indicating a deployment is being performed in a given namespace.
A thread is started that will using a short interval check status for the deployment
and indicate when it is completed. This will allow to communicate the current deployment
status without having to check status in all namespaces simultaneously.

This will also disable deployment buttons in the ui when there is an ongoing deployment for any given namespace.

This is based on periodic-status-checking PR https://github.com/fiaas/skipper/pull/47 and expands on it.