### PR TITLE
Support forcing bootstrapping of namespaces

### DIFF
--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -44,7 +44,7 @@ class Deployer(object):
         self._spec_extension = spec_config_extension
         self._deploy_interval = deploy_interval
 
-    def deploy(self, namespaces=None):
+    def deploy(self, namespaces=None, force_bootstrap=False):
         deploy_counter.inc()
         last_deploy_gauge.set_to_current_time()
         deployment_configs = self._cluster.find_deployment_configs(NAME)
@@ -57,7 +57,7 @@ class Deployer(object):
                 spec_config = self._load_spec(channel)
                 LOG.debug(spec_config)
                 self._deploy(deployment_config, channel, spec_config)
-                if requires_bootstrap(deployment_config):
+                if force_bootstrap or requires_bootstrap(deployment_config):
                     self._bootstrap(deployment_config, channel, spec_config)
             except Exception:
                 LOG.exception("Failed to deploy %s in %s", deployment_config.name, deployment_config.namespace)

--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -20,22 +20,28 @@ function getStatus() {
                        + "<td>" + [item.description].join('') + "</td>"
                        + "<td>" + item.channel + "</td>"
                        + "<td>" + item.version + "</td>"
-                       + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\">Deploy</button></td>"
+                       + "<td><button class=\"btn btn-primary btn-block btnDeploy\" type=\"submit\" data-namespace=\"" + item.namespace + "\" data-toggle=\"modal\" data-target=\"#deployModal\">Deploy</button></td>"
                        + "</tr>";
            $('#tbody').append(eachrow);
        });
-       $(".btnDeploy").each(function(){
-           var $this = $(this);
-           $this.click(function(){
-               $.ajax({
-                   type: "POST",
-                   contentType: "application/json",
-                   url: "/api/deploy",
-                   data: "{\"namespaces\": [\"" + $(this).data('namespace') + "\"]}",
-                   success: function(data) {
-                       alert("Deployment to " + $this.data("namespace") + " scheduled successfully");
-                   }
-               });
+       $("#deployModal").on("show.bs.modal", function (event) {
+            var button = $(event.relatedTarget);
+            var namespace = button.data("namespace");
+            var modal = $(this);
+            modal.find(".modal-title").text("Deploy fiaas-deploy-daemon to namespace: " + namespace + "?");
+            modal.find(".modal-body input").val(namespace);
+       });
+       $("#deployModal").find(".btn-primary").click(function(){
+           var forceBootstrap = $("#deployModal").find("#force-bootstrap").is(":checked");
+           var namespace = $("#deployModal").find("#namespace").val();
+           $.ajax({
+               type: "POST",
+               contentType: "application/json",
+               url: "/api/deploy",
+               data: "{\"namespaces\": [\"" + namespace + "\"], \"force_bootstrap\": " + (forceBootstrap ? "true" : "false") + "}",
+               success: function(data) {
+                   $("#deployModal").modal("hide");
+               }
            });
        });
     }

--- a/fiaas_skipper/web/templates/status.html
+++ b/fiaas_skipper/web/templates/status.html
@@ -44,6 +44,34 @@
     </table>
     <p><small>Refreshed periodically</small></p>
    </div>
+
+<div class="modal fade" id="deployModal" tabindex="-1" role="dialog" aria-labelledby="deployModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="deployModalLabel">Deploy</h4>
+      </div>
+      <div class="modal-body">
+        <form>
+          <div class="form-group">
+            <input type="hidden" class="form-control" id="namespace">
+          </div>
+          <div class="form-group">
+            <input type="checkbox" class="form-check" id="force-bootstrap">
+            <label class="form-check-label" for="defaultCheck1">
+              Force bootstrap
+            </label>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary">Deploy</button>
+      </div>
+    </div>
+  </div>
+</div>
 {%- endblock %}
 
 {% block scripts %}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ GENERIC_REQ = [
 ]
 
 WEB_REQ = [
-    "Flask == 0.12",
+    "Flask == 1.0.2",
     "flask-talisman==0.5.1",
     "blinker == 1.4",
     "flask-bootstrap",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ WEB_REQ = [
     "Flask == 1.0.2",
     "flask-talisman==0.5.1",
     "blinker == 1.4",
-    "flask-bootstrap",
+    "flask-bootstrap == 3.3.7.1",
     "flask-nav",
     "dominate"
 ]

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -101,6 +101,13 @@ class TestDeployer(object):
         deployer.deploy()
         assert 2 == deployer._deploy.call_count
 
+    def test_deploys_with_bootstrap_when_force_flag_set(self, cluster, release_channel_factory):
+        bootstrap = mock.MagicMock(name="bootstrap")
+        deployer = Deployer(cluster, release_channel_factory, bootstrap, deploy_interval=0)
+        deployer._deploy = mock.MagicMock(name="_deploy")
+        deployer.deploy(namespaces=["test1"], force_bootstrap=True)
+        assert 1 == bootstrap.call_count
+
     @pytest.mark.usefixtures("config_map_find")
     def test_deployment_statuses(self, cluster, release_channel_factory, deployment_find, application_find):
         deployment_find.return_value = (

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -65,3 +65,9 @@ class TestApi(object):
             response = app.post('/api/deploy')
             assert response.status_code == 200
             assert mock.called
+
+    def test_deploy_force_bootstrap(self, app):
+        with patch('fiaas_skipper.deploy.deploy.Deployer.deploy') as mock:
+            response = app.post('/api/deploy', json={'force_bootstrap': True, 'namespaces': ['test1']})
+            assert response.status_code == 200
+            mock.assert_called_with(force_bootstrap=True, namespaces=['test1'])


### PR DESCRIPTION
This extends the deploy endpoint to accept a flag for forcing bootstrap of namespaces with fiaas-deploy-daemon.
Web UI has also been extended to display a modal dialog with a force-bootstrap checkbox when deploying.

Additionally this bumps the flask version to 1.x and pins the flask bootstrap version to avoid possible issues with future versions.