### PR TITLE
Allow configuring interval for checking status of namespaces

### DIFF
--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -84,7 +84,7 @@ def main():
             deployer = TprDeployer(cluster=cluster, release_channel_factory=release_channel_factory,
                                    bootstrap=TprBootstrapper(), spec_config_extension=spec_config_extension)
         # Do period checking of deployment status across all namespaces
-        status_tracker = StatusTracker(cluster=cluster, application=application)
+        status_tracker = StatusTracker(cluster=cluster, application=application, interval=cfg.status_update_interval)
         status_tracker.start()
         if not cfg.disable_autoupdate:
             updater = AutoUpdater(release_channel_factory=release_channel_factory, deployer=deployer,

--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -52,6 +52,8 @@ class Configuration(Namespace):
                             default=DEFAULT_OVERRIDE_SPEC_FILE)
         parser.add_argument("--disable-autoupdate", help="Disable auto updating of fiaas-deploy-daemon.",
                             action="store_true")
+        parser.add_argument("--status-update-interval", help="How frequently to check status of namespaces.",
+                            default=30)
         api_parser = parser.add_argument_group("API server")
         api_parser.add_argument("--api-server", help="Address of the api-server to use (IP or name)",
                                 default="https://kubernetes.default.svc.cluster.local")

--- a/fiaas_skipper/deploy/deploy.py
+++ b/fiaas_skipper/deploy/deploy.py
@@ -17,7 +17,6 @@ from prometheus_client import Counter, Gauge
 LOG = logging.getLogger(__name__)
 NAME = 'fiaas-deploy-daemon'
 DEPLOY_INTERVAL = 30
-STATUS_UPDATE_INTERVAL = 300
 
 last_deploy_gauge = Gauge("last_triggered_deployment", "Timestamp for when last deployment was performed")
 deploy_counter = Counter("deployments_triggered", "Number of deployments triggered and performed")
@@ -136,13 +135,14 @@ def _get_status(dep, app):
 
 
 class StatusTracker(Thread):
-    def __init__(self, cluster, application):
+    def __init__(self, cluster, application, interval):
         Thread.__init__(self)
         self.daemon = True
         self._cluster = cluster
         self._status = {}
         self._application = application
         self._statuslock = Lock()
+        self._interval = interval
 
     def __call__(self):
         with self._statuslock:
@@ -174,4 +174,4 @@ class StatusTracker(Thread):
     def run(self):
         while True:
             self._update_status()
-            time.sleep(STATUS_UPDATE_INTERVAL)
+            time.sleep(self._interval)

--- a/helm/fiaas-skipper/templates/config_map.yaml
+++ b/helm/fiaas-skipper/templates/config_map.yaml
@@ -14,5 +14,6 @@ data:
     {{with .Values.CRD}}enable-crd-support: {{.}}{{end}}
     {{with .Values.baseurl}}baseurl: {{.}}{{end}}
     {{with .Values.debug}}debug: true{{end}}
+    {{with .Values.statusUpdateInterval}}status-update-interval: {{.}}{{end}}
   fiaas_override.yaml: |
 {{ .Files.Get "fiaas_override.yaml" | indent 4 }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -16,3 +16,4 @@ baseurl: 'http://fiaas-release.delivery-pro.schibsted.io'
 annotations: {}
 rbac:
   enabled: false
+statusUpdateInterval: 30

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -138,7 +138,7 @@ class TestStatusTracker(object):
 
     @pytest.mark.usefixtures("deployment_find")
     def test_deployment_statuses(self, cluster, application):
-        status_tracker = StatusTracker(cluster, application)
+        status_tracker = StatusTracker(cluster, application, interval=30)
         results = status_tracker._get_status()
 
         assert len(results) == 6


### PR DESCRIPTION
The default should be low but allow for specifing a less frequent interval
when multiple namespaces are configured where checking status could
be expensive.