### PR TITLE
Avoid throwing exception when trying to determine versions

### DIFF
--- a/fiaas_skipper/web/frontend.py
+++ b/fiaas_skipper/web/frontend.py
@@ -5,11 +5,10 @@ from __future__ import absolute_import
 import logging
 
 import pkg_resources
-import requests
 from dominate.tags import img
 from flask import Blueprint, render_template
 from flask_nav.elements import Navbar, View, Subgroup, Link, Text
-
+from fiaas_skipper.deploy.channel import ReleaseChannelError
 from .nav import nav
 
 LOG = logging.getLogger(__name__)
@@ -47,7 +46,7 @@ def status():
             channel = frontend.release_channel_factory("fiaas-deploy-daemon", tag)
             image = channel.metadata["image"]
             version = image.split(":")[-1]
-        except requests.exceptions.ConnectionError:
+        except ReleaseChannelError:
             LOG.exception("Unable to determine version for tag: %s" % tag)
             version = "unavailable"
         versions[tag] = version

--- a/fiaas_skipper/web/frontend.py
+++ b/fiaas_skipper/web/frontend.py
@@ -2,13 +2,17 @@
 # -*- coding: utf-8
 from __future__ import absolute_import
 
+import logging
+
 import pkg_resources
+import requests
 from dominate.tags import img
 from flask import Blueprint, render_template
 from flask_nav.elements import Navbar, View, Subgroup, Link, Text
 
 from .nav import nav
 
+LOG = logging.getLogger(__name__)
 FIAAS_VERSION = pkg_resources.require("fiaas_skipper")[0].version
 
 frontend = Blueprint('frontend', __name__)
@@ -39,9 +43,14 @@ def index():
 def status():
     versions = {}
     for tag in ("stable", "latest"):
-        channel = frontend.release_channel_factory("fiaas-deploy-daemon", tag)
-        image = channel.metadata["image"]
-        versions[tag] = image.split(":")[-1]
+        try:
+            channel = frontend.release_channel_factory("fiaas-deploy-daemon", tag)
+            image = channel.metadata["image"]
+            version = image.split(":")[-1]
+        except requests.exceptions.ConnectionError:
+            LOG.exception("Unable to determine version for tag: %s" % tag)
+            version = "unavailable"
+        versions[tag] = version
     return render_template('status.html', versions=versions)
 
 

--- a/tests/fiaas_skipper/deploy/test_channel.py
+++ b/tests/fiaas_skipper/deploy/test_channel.py
@@ -2,7 +2,12 @@
 # -*- coding: utf-8
 from __future__ import absolute_import
 
+import pytest
+import requests
+
 from fiaas_skipper.deploy import ReleaseChannelFactory
+from fiaas_skipper.deploy.channel import ReleaseChannelError
+
 
 METADATA = {"key1": "value1", "spec": "http://example.com/config.yaml"}
 CONFIG = """
@@ -21,3 +26,25 @@ class TestReleaseChannelFactory(object):
         assert rc.tag == 'tag'
         assert rc.metadata == METADATA
         assert rc.spec == CONFIG
+
+    def test_fetch_metadata_raises_exception_on_connection_error(self, requests_mock):
+        requests_mock.get("http://example.com/name/tag.json", exc=requests.exceptions.ConnectionError)
+
+        factory = ReleaseChannelFactory(baseurl="http://example.com")
+        with pytest.raises(ReleaseChannelError):
+            factory('name', 'tag')
+
+    def test_fetch_metadata_raises_exception_on_not_found(self, requests_mock):
+        requests_mock.get("http://example.com/name/tag.json", text='Not Found', status_code=404)
+
+        factory = ReleaseChannelFactory(baseurl="http://example.com")
+        with pytest.raises(ReleaseChannelError):
+            factory('name', 'tag')
+
+    def test_fetch_metadata_raises_exception_when_unable_to_get_config(self, requests_mock):
+        requests_mock.get("http://example.com/name/tag.json", json=METADATA)
+        requests_mock.get("http://example.com/config.yaml", text='Not Found', status_code=404)
+
+        factory = ReleaseChannelFactory(baseurl="http://example.com")
+        with pytest.raises(ReleaseChannelError):
+            factory('name', 'tag')


### PR DESCRIPTION
This can happen if an operator would specify an invalid baseurl where
release metadata can be found.