### PR TITLE
Add flag for installing fiaas-deploy-daemon configmap when installing fiaas-skipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ helm install ./helm/fiaas-skipper --name "fiaas-skipper" --set rbac.enabled="tru
 
 For more information on permissions required for fiaas-controller see [FIAAS operators guide].
 
+Skipper will look for a fiaas-deploy-daemon configmap across namespaces in the cluster and will bootstrap and deploy a fiaas-deploy-daemon instance for any that are found. By default this configmap is not added when skipper is installed but the install command can be extended with `--set addFiaasDeployDaemonConfigmap="true"` to include the configmap which will make fiaas-skipper start an instance of the fiaas-deploy-daemon once installed. This is useful when bootstrapping fiaas for the first time in a new cluster.
+
 ## Deploying fiaas-deploy-daemon to a new namespace
 
 Deploying fiaas-deploy-daemon to a new namespace can be done in a few simple steps, assuming you already have Skipper running in your cluster:

--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.addFiaasDeployDaemonConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: fiaas-deploy-daemon
+    name: fiaas-deploy-daemon
+  name: fiaas-deploy-daemon
+data:
+  cluster_config.yaml: |-
+    ingress-suffix:
+    - {{ .Values.ingress.suffix }}
+    {{with .Values.TPR}}enable-tpr-support: {{.}}{{end}}
+    {{with .Values.CRD}}enable-crd-support: {{.}}{{end}}
+{{- end}}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -7,6 +7,7 @@ ingress:
   fqdn: fiaas-skipper.yourcluster.local
   enableTLS: true
   annotations: {}
+  suffix: yourcluster.local
 deployment:
   # include the resource requests and limits
   includeResourceUsage: true
@@ -17,3 +18,5 @@ annotations: {}
 rbac:
   enabled: false
 statusUpdateInterval: 30
+# Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed
+addFiaasDeployDaemonConfigmap: false


### PR DESCRIPTION
If the flag is set this will bootstrap the daemon when skipper is installed, in the
same namespace. This is useful for first time users or in a simple setup where there is only one namespace. The fiaas-deploy-daemon configmap can then of course be updated afterwards but the fiaas-deploy-daemon would have been bootstrapped already. 