### PR TITLE
Specify argument type for status-update-interval

### DIFF
--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -53,7 +53,7 @@ class Configuration(Namespace):
         parser.add_argument("--disable-autoupdate", help="Disable auto updating of fiaas-deploy-daemon.",
                             action="store_true")
         parser.add_argument("--status-update-interval", help="How frequently to check status of namespaces.",
-                            default=30)
+                            type=int, default=30)
         api_parser = parser.add_argument_group("API server")
         api_parser.add_argument("--api-server", help="Address of the api-server to use (IP or name)",
                                 default="https://kubernetes.default.svc.cluster.local")


### PR DESCRIPTION
By default it is string but it should be int.