### PR TITLE
Adding codacy config to make prospector use Python 3

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+---
+engines:
+  prospector:
+    python_version: 3


### PR DESCRIPTION
As can be seen in #59, when Codacy analyses the codebase, it seems to be running Prospector using Python 2. According to Codacy support, adding a configuration like this might solve the problem. They pointed to documentation that indicated it would only work for pylint, but I explicitly asked about Prospector, so there is a chance the documentation is outdated.

Giving it a go anyways.