### PR TITLE
Explicitly set docker image tag in helm chart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 after_success: tox -e coverage
 deploy:
   provider: script
-  script: bin/docker_push && bin/publish_helm_chart
+  script: VERSION=$(python setup.py --version) bash -c 'bin/docker_push && bin/publish_helm_chart'
   skip_cleanup: true
   on:
     branch: master

--- a/bin/docker_push
+++ b/bin/docker_push
@@ -2,7 +2,6 @@
 
 set -evuo pipefail
 
-VERSION=$(python setup.py --version)
 DOCKER_IMAGE="${TRAVIS_REPO_SLUG}:${VERSION/+/-}"
 
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin

--- a/bin/publish_helm_chart
+++ b/bin/publish_helm_chart
@@ -11,10 +11,10 @@ helm init --client-only
 
 echo "Publishing helm chart"
 
+sed -i 's/tag:.*/tag: '"${VERSION/+/-}"'/g' helm/fiaas-skipper/values.yaml
+
 output="$(cd helm; helm package fiaas-skipper)"
-echo $output
 package=`expr "$output" : 'Successfully packaged chart and saved it to: \(.*\)'`
-echo $package
 
 git clone https://github.com/fiaas/helm helm-repo
 mv $package helm-repo/


### PR DESCRIPTION
This updates the helm/fiaas-skipper/values.yaml file in place with
version reference for the image.tag before packaging the helm chart.

This will ensure that the helm chart that will be published contains a
reference to the docker image tag with the version reference instead of
relying on latest.