### PR TITLE
Tag releases and publish on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,9 @@ script:
   - bin/docker_build
 after_success:
 - tox -e coverage
-- bin/tag_release
 deploy:
   provider: script
-  script: VERSION=$(python setup.py --version) bash -c 'bin/docker_push && bin/publish_helm_chart'
+  script: VERSION=$(python setup.py --version) TAG=$(bin/tag_release|tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'
   skip_cleanup: true
   on:
     branch: master
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ install:
 script:
   - tox
   - bin/docker_build
-after_success: tox -e coverage
+after_success:
+- tox -e coverage
+- bin/tag_release
 deploy:
   provider: script
   script: VERSION=$(python setup.py --version) bash -c 'bin/docker_push && bin/publish_helm_chart'
   skip_cleanup: true
   on:
     branch: master
+    tags: true

--- a/bin/publish_helm_chart
+++ b/bin/publish_helm_chart
@@ -12,6 +12,7 @@ helm init --client-only
 echo "Publishing helm chart"
 
 sed -i 's/tag:.*/tag: '"${VERSION/+/-}"'/g' helm/fiaas-skipper/values.yaml
+sed -i 's/version:.*/version: '"${TRAVIS_TAG/v/}"'/g' helm/fiaas-skipper/Chart.yaml
 
 output="$(cd helm; helm package fiaas-skipper)"
 package=`expr "$output" : 'Successfully packaged chart and saved it to: \(.*\)'`
@@ -21,7 +22,7 @@ mv $package helm-repo/
 cd helm-repo/
 helm repo index . --url https://fiaas.github.io/helm/
 git add .
-git commit -a -m "Release fiaas-skipper"
-git push https://${GIT_USERNAME}:${GIT_APITOKEN}@github.com/fiaas/helm
+git commit -a -m "Release fiaas-skipper ${TRAVIS_TAG}"
+git push https://${GITHUBKEY}@github.com/fiaas/helm
 
 echo "Successfully pushed helm chart"

--- a/bin/publish_helm_chart
+++ b/bin/publish_helm_chart
@@ -12,7 +12,7 @@ helm init --client-only
 echo "Publishing helm chart"
 
 sed -i 's/tag:.*/tag: '"${VERSION/+/-}"'/g' helm/fiaas-skipper/values.yaml
-sed -i 's/version:.*/version: '"${TRAVIS_TAG/v/}"'/g' helm/fiaas-skipper/Chart.yaml
+sed -i 's/version:.*/version: '"${TAG/v/}"'/g' helm/fiaas-skipper/Chart.yaml
 
 output="$(cd helm; helm package fiaas-skipper)"
 package=`expr "$output" : 'Successfully packaged chart and saved it to: \(.*\)'`
@@ -22,7 +22,7 @@ mv $package helm-repo/
 cd helm-repo/
 helm repo index . --url https://fiaas.github.io/helm/
 git add .
-git commit -a -m "Release fiaas-skipper ${TRAVIS_TAG}"
+git commit -a -m "Release fiaas-skipper ${TAG}"
 git push https://${GITHUBKEY}@github.com/fiaas/helm
 
 echo "Successfully pushed helm chart"

--- a/bin/tag_release
+++ b/bin/tag_release
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -evuo pipefail
 # Only do tagging on merge to master
-if ([ "$TRAVIS_BRANCH" == "master" ] && [[ -z "$TRAVIS_TAG" ]]) &&
-    [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  go get -u -v github.com/screwdriver-cd/gitversion
-  GIT_TAG=$(gitversion --prefix=v bump auto 2>&1|tail -1)
-  git push https://$GITHUBKEY@github.com/fiaas/skipper $GIT_TAG
-  echo "successfully tagged release"
-fi
+go get -u -v github.com/screwdriver-cd/gitversion
+GIT_TAG=$(gitversion --prefix=v bump auto 2>&1|tail -1)
+git push https://$GITHUBKEY@github.com/fiaas/skipper $GIT_TAG
+echo "successfully tagged release"
+echo "$GIT_TAG"

--- a/bin/tag_release
+++ b/bin/tag_release
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -evuo pipefail
+# Only do tagging on merge to master
+if ([ "$TRAVIS_BRANCH" == "master" ] && [[ -z "$TRAVIS_TAG" ]]) &&
+    [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  go get -u -v github.com/screwdriver-cd/gitversion
+  GIT_TAG=$(gitversion --prefix=v bump auto 2>&1|tail -1)
+  git push https://$GITHUBKEY@github.com/fiaas/skipper $GIT_TAG
+  echo "successfully tagged release"
+fi


### PR DESCRIPTION
This introduces automatic tagging with semver on merges to master which
will generate releases based on pre-existings tags. The utility used
will automatically increment the patch version of the last tag: v0.0.1
to v0.0.2 or v0.1.0 to v.0.1.1.
The semver tag will be used to augment the helm chart version as well to
match the tag (excluding the v prefix) for better tracability.
When a tag has been pushed a release is created and docker image and
helm chart published.