### PR TITLE
Roll pods if fiaas_override is modified

### DIFF
--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         prometheus.io/port: http5000
         prometheus.io/scrape: "true"
         checksum/config: {{ include (print $.Template.BasePath "/config_map.yaml") . | sha256sum }}
+        checksum/fiaas_override: {{ .Files.Get "fiaas_override.yaml" | sha256sum }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}


### PR DESCRIPTION
Add checksum of fiaas_override.yaml as an annotation to the pod template, similar to the way config_map.yaml is handled.