### PR TITLE
Set tag in fiaas-deploy-daemon configmap

### DIFF
--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -12,4 +12,5 @@ data:
     - {{ .Values.ingress.suffix }}
     {{with .Values.TPR}}enable-tpr-support: {{.}}{{end}}
     {{with .Values.CRD}}enable-crd-support: {{.}}{{end}}
+  tag: {{.Values.fiaasDeployDaemonTag}}
 {{- end}}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -20,6 +20,7 @@ rbac:
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed
 addFiaasDeployDaemonConfigmap: false
+fiaasDeployDaemonTag: stable
 autoUpdate: true
 service:
   type: ClusterIP


### PR DESCRIPTION
Skipper needs this to determine which version of fiaas-deploy-daemon to deploy