### PR TITLE
Make it possible to override fiaas_override.yaml

### DIFF
--- a/helm/fiaas-skipper/templates/config_map.yaml
+++ b/helm/fiaas-skipper/templates/config_map.yaml
@@ -16,5 +16,9 @@ data:
     {{with .Values.debug}}debug: true{{end}}
     {{with .Values.statusUpdateInterval}}status-update-interval: {{.}}{{end}}
     {{with not .Values.autoUpdate}}disable-autoupdate: true{{end}}
-  fiaas_override.yaml: |
+  fiaas_override.yaml: |-
+{{ if .Values.fiaas_override_yaml -}}
+{{ .Values.fiaas_override_yaml | indent 4 }}
+{{- else -}}
 {{ .Files.Get "fiaas_override.yaml" | indent 4 }}
+{{- end -}}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -24,3 +24,4 @@ fiaasDeployDaemonTag: stable
 autoUpdate: true
 service:
   type: ClusterIP
+fiaas_override_yaml: null


### PR DESCRIPTION
fiaas_override_yaml is now a string(scalar) value that can be used to override
configuration in the fiaas.yml used to deploy fiaas-deploy-daemon.

example:
```
$ helm upgrade --namespace fiaas --install "fiaas-skipper" "fiaas-skipper" --repo https://fiaas.github.io/helm --set "fiaas_override_yaml=
annotations:
  ingress:
    \"nginx\.ingress\.kubernetes\.io/whitelist-source-range\": \"10.0.0.0/8\""
```

When `fiaas_override_yaml` is not set, we're falling back to the current behavior of using the `fiaas_override.yaml` file