### PR TITLE
Update release channel url

### DIFF
--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -13,7 +13,7 @@ deployment:
   includeResourceUsage: true
 TPR: false
 CRD: true
-baseurl: 'http://fiaas-release.delivery-pro.schibsted.io'
+baseurl: 'https://fiaas.github.io/releases'
 annotations: {}
 rbac:
   enabled: false


### PR DESCRIPTION
The release channel metadata has been moved to github and is now available through github pages https://fiaas.github.io/releases/