### PR TITLE
Cache wheels between docker builds to speed up building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.wheel_cache
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ RUN apk --no-cache add \
     git \
     yaml-dev
 COPY . /skipper
+COPY .wheel_cache/*.whl /links/
 WORKDIR /skipper
-RUN pip wheel . --wheel-dir=/wheels/
+RUN pip wheel . --no-cache-dir --wheel-dir=/wheels/ --find-links=/links/
 
 FROM common as production
 # Get rid of all build dependencies, install application using only pre-built binary wheels
 COPY --from=build /wheels/ /wheels/
-RUN pip install --no-index --find-links=/wheels/ --only-binary all /wheels/fiaas_skipper*.whl
+RUN pip install --no-index --no-cache-dir --find-links=/wheels/ --only-binary all /wheels/fiaas_skipper*.whl
 EXPOSE 5000
 CMD ["skipper"]

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -2,4 +2,16 @@
 
 set -evuo pipefail
 
+# Put cached wheels into the docker context so we can use it in our Dockerfile
+mkdir -p .wheel_cache
+find ~/.cache/pip/wheels -name "*.whl" -execdir cp "{}" "${PWD}/.wheel_cache" \;
+
 docker build --pull . -t "${TRAVIS_REPO_SLUG}:latest"
+
+# Grab the wheels out of the final docker image and stuff them in the pip cache directory
+undocker=$(mktemp -d)
+docker image save "${TRAVIS_REPO_SLUG}" | tar -C "${undocker}" -x
+
+for t in "${undocker}"/*/layer.tar; do
+  tar -v -C ~/.cache/pip/ --wildcards -x "wheels/*.whl" -f "${t}" 2>/dev/null || true
+done


### PR DESCRIPTION
Some of our dependencies does not have pre-built wheels on PyPI, and can take a while to build. At the same time, since we are building inside docker, we don't get the benefit of the pip cache available in Travis.

These changes will inject the wheels in the pip cache into the docker context, and then use them when building. In order for the cache to have any value, we need to take the wheels we do build out of the image and put them into the pip cache again. This is done by "saving" the image to a temporary directory, then searching the layers for files matching the pattern `/wheels/*.whl`, and stuffing them into the pip cache.

Unfortunately, pip uses a naming scheme that isn't documented, so we can't actually put the wheels in the proper place in the cache. That doesn't matter though, as long as Travis saves them for us for next time, we can use `find` to get them out again.