### PR TITLE
Support configuring fiaas-deploy-daemon configmaps in multiple namespaces

### DIFF
--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -28,7 +28,7 @@ data:
     - {{ .Values.ingress.suffix }}
   tag: {{.Values.fiaasDeployDaemonTag}}
 {{- else }}
-{{- range $namespace, $config := .Values.fiaasDeployDaemonConfigMaps }}
+{{- range $namespace, $config := .Values.fiaasDeployDaemonConfigMaps.namespaces }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 {{- if .Values.addFiaasDeployDaemonConfigmap }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,6 +29,7 @@ data:
   tag: {{.Values.fiaasDeployDaemonTag}}
 {{- else }}
 {{- range $namespace, $config := .Values.fiaasDeployDaemonConfigMaps }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -26,4 +26,18 @@ data:
     ingress-suffix:
     - {{ .Values.ingress.suffix }}
   tag: {{.Values.fiaasDeployDaemonTag}}
+{{- else }}
+{{- range $namespace, $config := .Values.fiaasDeployDaemonConfigMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: fiaas-deploy-daemon
+    name: fiaas-deploy-daemon
+  name: fiaas-deploy-daemon
+  namespace: {{ $namespace }}
+data:
+  cluster_config.yaml: {{ $config.clusterConfig | quote }}
+  tag: {{$config.tag | quote }}
+{{- end}}
 {{- end}}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -46,11 +46,11 @@ fiaasDeployDaemonConfigMaps: {}
 #    clusterConfig: |-
 #      enable-crd-support: true
 #      ingress-suffix:
-#      - dev.yourcluster.local
+#      - dev.yourcluster.example.com
 #    tag: latest
 #  prod:
 #    clusterConfig: |-
 #      enable-crd-support: true
 #      ingress-suffix:
-#      - yourcluster.local
+#      - yourcluster.example.com
 #    tag: stable

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -42,15 +42,16 @@ fiaasDeployDaemonConfigMaps: {}
 # example of how to use fiaasDeployDaemonConfigMaps:
 # (can not be used at the same time as `addFiaasDeployDaemonConfigmap`)
 #fiaasDeployDaemonConfigMaps:
-#  dev:
-#    clusterConfig: |-
-#      enable-crd-support: true
-#      ingress-suffix:
-#      - dev.yourcluster.example.com
-#    tag: latest
-#  prod:
-#    clusterConfig: |-
-#      enable-crd-support: true
-#      ingress-suffix:
-#      - yourcluster.example.com
-#    tag: stable
+#  namespaces:
+#    dev:
+#      clusterConfig: |-
+#        enable-crd-support: true
+#        ingress-suffix:
+#        - dev.yourcluster.example.com
+#      tag: latest
+#    prod:
+#      clusterConfig: |-
+#        enable-crd-support: true
+#        ingress-suffix:
+#        - yourcluster.example.com
+#      tag: stable

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,3 +38,19 @@ autoUpdate: true
 service:
   type: ClusterIP
 fiaas_override_yaml: null
+fiaasDeployDaemonConfigMaps: {}
+# example of how to use fiaasDeployDaemonConfigMaps:
+# (can not be used at the same time as `addFiaasDeployDaemonConfigmap`)
+#fiaasDeployDaemonConfigMaps:
+#  dev:
+#    clusterConfig: |-
+#      enable-crd-support: true
+#      ingress-suffix:
+#      - dev.yourcluster.local
+#    tag: latest
+#  prod:
+#    clusterConfig: |-
+#      enable-crd-support: true
+#      ingress-suffix:
+#      - yourcluster.local
+#    tag: stable


### PR DESCRIPTION
Add a value to the helm chart which can be used to configure fiaas-deploy-daemon configmaps in different user-specified namespaces. 
I'm not sure if it makes sense (or how) to deprecate or remove `addFiaasDeployDaemonConfigmap` at the same time.

This should solve #89 