### PR TITLE
Use buildx for multi-arch images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,7 +85,6 @@ pyvenv.cfg
 .venv
 pip-selfcheck.json
 ### Linux template
-*~
 
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
@@ -108,7 +107,6 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-.Python
 build/
 dist/
 develop-eggs/
@@ -184,7 +182,6 @@ celerybeat-schedule
 
 # Environments
 .env
-.venv
 env/
 venv/
 ENV/
@@ -237,9 +234,6 @@ $RECYCLE.BIN/
 cmake-build-debug/
 cmake-build-release/
 
-# Mongo Explorer plugin:
-.idea/**/mongoSettings.xml
-
 ## File-based project format:
 *.iws
 *.iml
@@ -264,4 +258,13 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+## Misc files
 Dockerfile
+.github
+helm
+tests
+.codacy.yml
+.prospector.yaml
+LICENSE
+README.md
+

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ ENV/
 
 # Emacs directory specific variables
 .dir-locals.el
+
+
+## Misc files
+skipper.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ after_success:
   - tox -e coverage
 deploy:
   provider: script
-  script: VERSION=$(python setup.py --version) TAG=$(bin/tag_release|tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'
+  script:
+    - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+    - VERSION=$(python setup.py --version) TAG=$(bin/tag_release|tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'
   skip_cleanup: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - secure: "PM9LanQe58AN18oTqQ+DXqDQ4vMove/AbG5oqZCCL1aEQHuG46fp8xNml5GRqD9dFl67U8Ml/FziWGWYqr6QSChq3cyZvjxjtcfwytmLyb9cWt3U0z8giveN01c4grdetbhTlyliCxy3nU+VyyMBK8Fd8IZUYU9nVNemGYQhX+7x/wzyxS9gmhGZvx1RxXG6iyI6vN+SFF2UXHxvIz/bTgRiOEz4wXcl1nY/X2EH5AxYDKzvaUGg+2YKvP9ktfU1P9B08XqmQgcaJnzgwaOSWA7EMcSAp67tCtFk7qqZKvN1dce5uSRtHt9kYBWKEnShCYHq9p5m4kekBzycR4Xw11eoygkB+minFceTtTkbahCKaEaOIBsleUYal1mnDv8eNTuct0S7MXXyQ/pViLmfFPvmRsgG0p5ZEDwdeqzbyDwMbsmOAhnrCV2dtZR+hXivFNNodR2OMX2wq/1Vy3dxw2aeS61RYreXqhNHmMMK411QTJxFUQw8CH9KeplX3NBpPh+HjaxME6q2vniqnHq2YSoLlirjugq1vnC43/kt4ifQiN3ZAsRY7C+dDFDBsMJzsLpPkcDWh75MRYhj+/Yux8nExhGAFpZltv+F25xMmPfJYgPb5RtyEQ4pLxnngGzdG2eIOu7V4zdF0y1MmUqDqNuvHvtz8IGFkVoRBlmnMu8=" # DOCKER_PASSWORD
 before_install:
+  - sudo docker run --rm --privileged multiarch/qemu-user-static:register
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - docker --version
+  - docker info
 install:
   - pip install -e .[ci]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,29 @@
 language: python
 python:
-- '3.6'
+  - '3.6'
 sudo: required
-addons:
-  apt:
-    packages:
-      - docker-ce
 services:
-- docker
+  - docker
 cache: pip
 env:
   global:
-  - HELM_VERSION="v2.8.2"
-  - DOCKER_USERNAME=captainfiaas
-  - DOCKER_CLI_EXPERIMENTAL=enabled
-  - secure: "PM9LanQe58AN18oTqQ+DXqDQ4vMove/AbG5oqZCCL1aEQHuG46fp8xNml5GRqD9dFl67U8Ml/FziWGWYqr6QSChq3cyZvjxjtcfwytmLyb9cWt3U0z8giveN01c4grdetbhTlyliCxy3nU+VyyMBK8Fd8IZUYU9nVNemGYQhX+7x/wzyxS9gmhGZvx1RxXG6iyI6vN+SFF2UXHxvIz/bTgRiOEz4wXcl1nY/X2EH5AxYDKzvaUGg+2YKvP9ktfU1P9B08XqmQgcaJnzgwaOSWA7EMcSAp67tCtFk7qqZKvN1dce5uSRtHt9kYBWKEnShCYHq9p5m4kekBzycR4Xw11eoygkB+minFceTtTkbahCKaEaOIBsleUYal1mnDv8eNTuct0S7MXXyQ/pViLmfFPvmRsgG0p5ZEDwdeqzbyDwMbsmOAhnrCV2dtZR+hXivFNNodR2OMX2wq/1Vy3dxw2aeS61RYreXqhNHmMMK411QTJxFUQw8CH9KeplX3NBpPh+HjaxME6q2vniqnHq2YSoLlirjugq1vnC43/kt4ifQiN3ZAsRY7C+dDFDBsMJzsLpPkcDWh75MRYhj+/Yux8nExhGAFpZltv+F25xMmPfJYgPb5RtyEQ4pLxnngGzdG2eIOu7V4zdF0y1MmUqDqNuvHvtz8IGFkVoRBlmnMu8=" # DOCKER_PASSWORD
+    - HELM_VERSION="v2.8.2"
+    - DOCKER_USERNAME=captainfiaas
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - secure: "PM9LanQe58AN18oTqQ+DXqDQ4vMove/AbG5oqZCCL1aEQHuG46fp8xNml5GRqD9dFl67U8Ml/FziWGWYqr6QSChq3cyZvjxjtcfwytmLyb9cWt3U0z8giveN01c4grdetbhTlyliCxy3nU+VyyMBK8Fd8IZUYU9nVNemGYQhX+7x/wzyxS9gmhGZvx1RxXG6iyI6vN+SFF2UXHxvIz/bTgRiOEz4wXcl1nY/X2EH5AxYDKzvaUGg+2YKvP9ktfU1P9B08XqmQgcaJnzgwaOSWA7EMcSAp67tCtFk7qqZKvN1dce5uSRtHt9kYBWKEnShCYHq9p5m4kekBzycR4Xw11eoygkB+minFceTtTkbahCKaEaOIBsleUYal1mnDv8eNTuct0S7MXXyQ/pViLmfFPvmRsgG0p5ZEDwdeqzbyDwMbsmOAhnrCV2dtZR+hXivFNNodR2OMX2wq/1Vy3dxw2aeS61RYreXqhNHmMMK411QTJxFUQw8CH9KeplX3NBpPh+HjaxME6q2vniqnHq2YSoLlirjugq1vnC43/kt4ifQiN3ZAsRY7C+dDFDBsMJzsLpPkcDWh75MRYhj+/Yux8nExhGAFpZltv+F25xMmPfJYgPb5RtyEQ4pLxnngGzdG2eIOu7V4zdF0y1MmUqDqNuvHvtz8IGFkVoRBlmnMu8=" # DOCKER_PASSWORD
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker --version
 install:
-- pip install -e .[ci]
+  - pip install -e .[ci]
 script:
   - tox
   - bin/docker_build
 after_success:
-- tox -e coverage
+  - tox -e coverage
 deploy:
   provider: script
   script: VERSION=$(python setup.py --version) TAG=$(bin/tag_release|tail -1) bash -c 'bin/docker_push && bin/publish_helm_chart'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - secure: "PM9LanQe58AN18oTqQ+DXqDQ4vMove/AbG5oqZCCL1aEQHuG46fp8xNml5GRqD9dFl67U8Ml/FziWGWYqr6QSChq3cyZvjxjtcfwytmLyb9cWt3U0z8giveN01c4grdetbhTlyliCxy3nU+VyyMBK8Fd8IZUYU9nVNemGYQhX+7x/wzyxS9gmhGZvx1RxXG6iyI6vN+SFF2UXHxvIz/bTgRiOEz4wXcl1nY/X2EH5AxYDKzvaUGg+2YKvP9ktfU1P9B08XqmQgcaJnzgwaOSWA7EMcSAp67tCtFk7qqZKvN1dce5uSRtHt9kYBWKEnShCYHq9p5m4kekBzycR4Xw11eoygkB+minFceTtTkbahCKaEaOIBsleUYal1mnDv8eNTuct0S7MXXyQ/pViLmfFPvmRsgG0p5ZEDwdeqzbyDwMbsmOAhnrCV2dtZR+hXivFNNodR2OMX2wq/1Vy3dxw2aeS61RYreXqhNHmMMK411QTJxFUQw8CH9KeplX3NBpPh+HjaxME6q2vniqnHq2YSoLlirjugq1vnC43/kt4ifQiN3ZAsRY7C+dDFDBsMJzsLpPkcDWh75MRYhj+/Yux8nExhGAFpZltv+F25xMmPfJYgPb5RtyEQ4pLxnngGzdG2eIOu7V4zdF0y1MmUqDqNuvHvtz8IGFkVoRBlmnMu8=" # DOCKER_PASSWORD
 before_install:
-  - sudo docker run --rm --privileged multiarch/qemu-user-static:register
+  - sudo apt install qemu-user
+  - sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset -p yes
   - sudo jq ".experimental=true" -- /etc/docker/daemon.json > /tmp/daemon.json
   - sudo mv /tmp/daemon.json /etc/docker/daemon.json
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
     - secure: "PM9LanQe58AN18oTqQ+DXqDQ4vMove/AbG5oqZCCL1aEQHuG46fp8xNml5GRqD9dFl67U8Ml/FziWGWYqr6QSChq3cyZvjxjtcfwytmLyb9cWt3U0z8giveN01c4grdetbhTlyliCxy3nU+VyyMBK8Fd8IZUYU9nVNemGYQhX+7x/wzyxS9gmhGZvx1RxXG6iyI6vN+SFF2UXHxvIz/bTgRiOEz4wXcl1nY/X2EH5AxYDKzvaUGg+2YKvP9ktfU1P9B08XqmQgcaJnzgwaOSWA7EMcSAp67tCtFk7qqZKvN1dce5uSRtHt9kYBWKEnShCYHq9p5m4kekBzycR4Xw11eoygkB+minFceTtTkbahCKaEaOIBsleUYal1mnDv8eNTuct0S7MXXyQ/pViLmfFPvmRsgG0p5ZEDwdeqzbyDwMbsmOAhnrCV2dtZR+hXivFNNodR2OMX2wq/1Vy3dxw2aeS61RYreXqhNHmMMK411QTJxFUQw8CH9KeplX3NBpPh+HjaxME6q2vniqnHq2YSoLlirjugq1vnC43/kt4ifQiN3ZAsRY7C+dDFDBsMJzsLpPkcDWh75MRYhj+/Yux8nExhGAFpZltv+F25xMmPfJYgPb5RtyEQ4pLxnngGzdG2eIOu7V4zdF0y1MmUqDqNuvHvtz8IGFkVoRBlmnMu8=" # DOCKER_PASSWORD
 before_install:
   - sudo docker run --rm --privileged multiarch/qemu-user-static:register
+  - sudo jq ".experimental=true" -- /etc/docker/daemon.json > /tmp/daemon.json
+  - sudo mv /tmp/daemon.json /etc/docker/daemon.json
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -13,6 +13,7 @@ if [[ "${CI:-}" == "true" ]]; then
 else
   PLATFORMS=linux/amd64
 fi
+echo "Building for ${PLATFORMS}"
 
 # Put cached wheels into the docker context so we can use it in our Dockerfile
 mkdir -p .wheel_cache
@@ -21,10 +22,15 @@ find "${CACHE_DIR}/wheels" -name "*.whl" -execdir cp "{}" "${PWD}/.wheel_cache" 
 
 # Create a multi-arch buildx builder if needed
 if docker buildx ls | grep docker-container | grep multi-arch &> /dev/null; then
+  echo "Using existing multi-arch builder"
   docker buildx use multi-arch
 else
-  docker buildx create --name multi-arch --use --platform "${PLATFORMS}"
+  echo "Creating new multi-arch builder"
+  docker buildx create --name multi-arch --driver docker-container --use --platform "${PLATFORMS}"
 fi
+
+echo "Buildx nodes:"
+docker buildx ls
 
 # Run multi-arch build
 docker buildx build --pull \

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -2,19 +2,43 @@
 
 set -evuo pipefail
 
+IMAGE_NAME=${TRAVIS_REPO_SLUG:-${USER}/skipper}
+TARBALL=build/skipper.tar
+CACHE_DIR=${PIP_CACHE_DIR:-~/.cache/pip}
+
+mkdir -p build
+
+if [[ "${CI:-}" == "true" ]]; then
+  PLATFORMS=linux/arm,linux/arm64,linux/amd64
+else
+  PLATFORMS=linux/amd64
+fi
+
 # Put cached wheels into the docker context so we can use it in our Dockerfile
 mkdir -p .wheel_cache
-find ~/.cache/pip/wheels -name "*.whl" -execdir cp "{}" "${PWD}/.wheel_cache" \;
+mkdir -p "${CACHE_DIR}/wheels"
+find "${CACHE_DIR}/wheels" -name "*.whl" -execdir cp "{}" "${PWD}/.wheel_cache" \;
 
-dockerma build --pull . -t "${TRAVIS_REPO_SLUG}:latest"
+# Create a multi-arch buildx builder if needed
+if docker buildx ls | grep docker-container | grep multi-arch &> /dev/null; then
+  docker buildx use multi-arch
+else
+  docker buildx create --name multi-arch --use --platform "${PLATFORMS}"
+fi
 
-# Grab the wheels out of the final docker image and stuff them in the pip cache directory
-undocker=$(mktemp -d)
-docker image save "${TRAVIS_REPO_SLUG}" | tar -C "${undocker}" -x
+# Run multi-arch build
+docker buildx build --pull \
+  --tag "${IMAGE_NAME}:latest" \
+  --platform="${PLATFORMS}" \
+  --output=type=tar,dest="${TARBALL}" .
 
-for t in "${undocker}"/*/layer.tar; do
-  tar -v -C ~/.cache/pip/ --wildcards -x "wheels/*.whl" -f "${t}" 2>/dev/null || true
-done
+# Rebuild to load the docker image for local testing
+docker buildx build --pull \
+  --tag "${IMAGE_NAME}:latest" \
+  --load .
+
+# Grab the wheels out of the tarball and stuff them in the pip cache directory
+tar -v -C "${CACHE_DIR}/wheels" --wildcards -x "*/wheels/*.whl" -f "${TARBALL}" 2>/dev/null || true
 
 # Clean up some wheels we don't want to cache
-find ~/.cache/pip/wheels -name "fiaas*.whl" -delete
+find "${CACHE_DIR}/wheels" -name "fiaas*.whl" -delete

--- a/bin/docker_push
+++ b/bin/docker_push
@@ -2,17 +2,15 @@
 
 set -evuo pipefail
 
-DOCKER_IMAGE="${TRAVIS_REPO_SLUG}:${VERSION/+/-}"
+IMAGE_NAME=${TRAVIS_REPO_SLUG:-${USER}/skipper}
+DOCKER_IMAGE="${IMAGE_NAME}:${VERSION/+/-}"
 
-echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-
-# When https://bitbucket.org/mortenlj/dockerma/issues/5 is resolved, we don't need all these
-docker tag "${TRAVIS_REPO_SLUG}:latest-arm" "${DOCKER_IMAGE}-arm"
-docker tag "${TRAVIS_REPO_SLUG}:latest-arm64" "${DOCKER_IMAGE}-arm64"
-docker tag "${TRAVIS_REPO_SLUG}:latest-amd64" "${DOCKER_IMAGE}-amd64"
-
-if [[ "${CI}" == "true" ]]; then
-    dockerma push "${DOCKER_IMAGE}"
-    dockerma push "${TRAVIS_REPO_SLUG}:latest"
+if [[ "${CI:-}" == "true" ]]; then
+  # Run multi-arch build and push it
+  docker buildx build --pull \
+    --tag "${IMAGE_NAME}:latest" \
+    --tag "${DOCKER_IMAGE}" \
+    --platform=linux/arm,linux/arm64,linux/amd64 \
+    --push .
     echo "Pushed image ${DOCKER_IMAGE}"
 fi


### PR DESCRIPTION
Not long after I created dockerma for building multi-arch images using qemu, docker released an experimental build command using buildkit, which among other things makes it possible to build multi-arch images using qemu.

Unfortunately, buildx doesn't support building locally and pushing later (because of the way multi-arch images is implemented). To solve this, we build the multi-arch image, then we build a single-arch docker image we can use for e2e tests, or when working locally (the docker_build script will work locally). When we push, we build again, with flags to push to repository.

This relies on using the docker cache for the second (local docker image) and third (push to registry) builds.

In addition, we continue the wheel cache, which is easier to implement when using buildx, as buildx has useful export options.
