### PR TITLE
Remove deprecated APIs removed in 1.16

### DIFF
--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Values.name }}"


### PR DESCRIPTION
See: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/