### PR TITLE
Add deletecollection to ClusterRole

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -14,6 +14,8 @@ ignore-paths:
 pep8:
   options:
     max-line-length: 120
+  disable:
+    - N815 # mixedCase variable in class scope
 
 mccabe:
   max-complexity: 10

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -63,6 +63,7 @@ rules:
       - list
       - update
       - watch
+      - deletecollection
 ---
 kind: ClusterRoleBinding
 {{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
The latest change in fiaas-deploy-daemon that added support for multiple ingresses uses deletecollection to clean-up