### PR TITLE
Use $ to get root scope when rendering configmap

### DIFF
--- a/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
+++ b/helm/fiaas-skipper/templates/fiaas-deploy-daemon-configmap.yaml
@@ -39,7 +39,7 @@ metadata:
   labels:
     app: fiaas-deploy-daemon
     name: fiaas-deploy-daemon
-    {{- range $key, $value := .Values.labels.global }}
+    {{- range $key, $value := $.Values.labels.global }}
     {{ $key }}: {{ $value }}
     {{- end }}
   name: fiaas-deploy-daemon


### PR DESCRIPTION
This fixes a nil reference issue with template rendering when the
`fiaasDeployDaemonConfigMaps` value is used to configure the content of
fiaas-deploy-daemon configmaps.

When changing scope in a template (with range in this case) it is no
longer possible to refer directly to e.g. `.Values.foo`. To refer to a value in
the root scope, we have to use `$.Values.foo`.