### PR TITLE
Add TLS annotations in ingress if TLS is enabled

### DIFF
--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -26,6 +26,15 @@ metadata:
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value }}
     {{- end }}
+    {{- if .Values.ingress.enableTLS }}
+      kubernetes.io/tls-acme: "true"
+      {{- if .Values.ingress.tlsClusterIssuer }}
+    certmanager.k8s.io/cluster-issuer: "{{ .Values.ingress.tlsClusterIssuer }}"
+      {{- end}}
+      {{- if .Values.ingress.tlsIssuer }}
+    certmanager.k8s.io/issuer: "{{ .Values.ingress.tlsIssuer }}"
+      {{- end}}
+    {{- end }}
 spec:
 {{- if .Values.ingress.enableTLS }}
   tls:

--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     {{ $key }}: {{ $value }}
     {{- end }}
     {{- if .Values.ingress.enableTLS }}
-      kubernetes.io/tls-acme: "true"
+    kubernetes.io/tls-acme: "true"
       {{- if .Values.ingress.tlsClusterIssuer }}
     certmanager.k8s.io/cluster-issuer: "{{ .Values.ingress.tlsClusterIssuer }}"
       {{- end}}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -22,6 +22,8 @@ ingress:
   fqdn: fiaas-skipper.yourcluster.local
   enableTLS: true
   annotations: {}
+  tlsClusterIssuer: ""
+  tlsIssuer: ""
   suffix: yourcluster.local
 deployment:
   # include the resource requests and limits


### PR DESCRIPTION
This PR will add TLS related annotations to the ingress if `enableTLS` flag is set to true.
This will make this chart closer to the `Mast` chart where this sort of behaviour is used.