### PR TITLE
parameterize clusterrolebinding subjects in chart

### DIFF
--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -84,9 +84,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: fiaas-controller
 subjects:
-- kind: Group
-  name: system:serviceaccounts
-  apiGroup: rbac.authorization.k8s.io
+{{ toYaml .Values.rbac.clusterRoleBinding.subjects }}
 roleRef:
   kind: ClusterRole
   name: fiaas-controller

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -32,6 +32,11 @@ baseurl: 'https://fiaas.github.io/releases'
 annotations: {}
 rbac:
   enabled: false
+  clusterRoleBinding:
+    subjects:
+    - kind: Group
+      name: system:serviceaccounts
+      apiGroup: rbac.authorization.k8s.io
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed
 addFiaasDeployDaemonConfigmap: false


### PR DESCRIPTION
currently the clusterrolebinding created with the helm chart is binding skipper's clusterrole, which is quite permissive, to all serviceaccounts in the cluster, including the default serviceaccount which pods receive by default. The result is that most pods in a given cluster will have free reign due to the presence of skipper's clusterrole and clusterrolebinding.

This change is meant to make it possible to change this default behavior while not ruining expected functionality for anyone else. In the future we will want to solve the issue once and for all by not applying skipper's clusterrole to each and every serviceaccount.