### PR TITLE
[Cert-manager] Update cert-manager annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - mkdir -vp ~/.docker/cli-plugins/
   - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
   - chmod a+x ~/.docker/cli-plugins/docker-buildx
-  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker login --username "${DOCKER_USERNAME}" --password-stdin <<< "${DOCKER_PASSWORD}" && docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 install:
   - pip install -e .[ci]
 script:

--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -29,10 +29,10 @@ metadata:
     {{- if .Values.ingress.enableTLS }}
     kubernetes.io/tls-acme: "true"
       {{- if .Values.ingress.tlsClusterIssuer }}
-    cert-manager.io/cluster-issuer: "{{ .Values.ingress.tlsClusterIssuer }}"
+    "{{ .Values.certManager.keyAnnotationPrefix }}/cluster-issuer": "{{ .Values.ingress.tlsClusterIssuer }}"
       {{- end}}
       {{- if .Values.ingress.tlsIssuer }}
-    cert-manager.io/issuer: "{{ .Values.ingress.tlsIssuer }}"
+    "{{ .Values.certManager.keyAnnotationPrefix }}/issuer": "{{ .Values.ingress.tlsIssuer }}"
       {{- end}}
     {{- end }}
 spec:

--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -29,10 +29,10 @@ metadata:
     {{- if .Values.ingress.enableTLS }}
     kubernetes.io/tls-acme: "true"
       {{- if .Values.ingress.tlsClusterIssuer }}
-    certmanager.k8s.io/cluster-issuer: "{{ .Values.ingress.tlsClusterIssuer }}"
+    cert-manager.io/cluster-issuer: "{{ .Values.ingress.tlsClusterIssuer }}"
       {{- end}}
       {{- if .Values.ingress.tlsIssuer }}
-    certmanager.k8s.io/issuer: "{{ .Values.ingress.tlsIssuer }}"
+    cert-manager.io/issuer: "{{ .Values.ingress.tlsIssuer }}"
       {{- end}}
     {{- end }}
 spec:

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -59,3 +59,8 @@ fiaasDeployDaemonConfigMaps: {}
 #      tag: stable
 labels:
   global: {}
+certManager:
+  # In cert-manager version v0.11.0 (https://github.com/jetstack/cert-manager/releases/tag/v0.11.0) the prefix that cert-manager uses for
+  # annotations was changed. From certmanager.k8s.io to cert-manager.io - see link for more details. In order to allow new behavior this
+  # parameter was added. Keeps previous behaviour but lets overwride for compatibility of newer versions
+  keyAnnotationPrefix: "certmanager.k8s.io"


### PR DESCRIPTION
Since [v0.11.0](https://github.com/jetstack/cert-manager/releases/tag/v0.11.0) that the annotation with `certmanager.k8s.io` have been renamed to `cert-manager.io`.

So this PR upgrades the skipper helm chart to match that.