### PR TITLE
give skipper its own service account

### DIFF
--- a/helm/fiaas-skipper/Chart.yaml
+++ b/helm/fiaas-skipper/Chart.yaml
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,4 +17,4 @@ apiVersion: v1
 description: Skipper controls deployment and updates of FIAAS components
 name: fiaas-skipper
 home: https://github.com/fiaas/skipper
-version: 0.1.0
+version: 0.2.0

--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
+      serviceAccountName: {{ .Values.Name }}
       containers:
       - name: "{{ .Values.name }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/fiaas-skipper/templates/deployment.yaml
+++ b/helm/fiaas-skipper/templates/deployment.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,7 +49,9 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Values.Name }}
+      {{- if .Value.rbac.enabled }}
+      serviceAccountName: {{ .Values.name }}
+      {{- end }}
       containers:
       - name: "{{ .Values.name }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 {{- if .Values.rbac.enabled }}
+
+---
 kind: ClusterRole
 {{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -89,13 +91,71 @@ roleRef:
   kind: ClusterRole
   name: fiaas-controller
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
+
+---
+kind: ClusterRole
+{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ .Values.name }}
+rules:
+  - apiGroups:
+      - fiaas.schibsted.io
+      - schibsted.io
+    resources:
+      - applications
+      - application-statuses
+      - statuses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - "" # "" indicates the core API group
+      - apps
+      - autoscaling
+      - apiextensions
+      - apiextensions.k8s.io
+      - extensions
+    resources:
+      - configmaps
+      - customresourcedefinitions
+      - deployments
+      - horizontalpodautoscalers
+      - ingresses
+      - pods
+      - resourcequotas
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - "" # "" indicates the core API group
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
 
 ---
 kind: ClusterRoleBinding
@@ -112,6 +172,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: fiaas-controller
+  name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io
+
 {{- end }}

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,8 +29,6 @@ rules:
     resources:
       - applications
       - application-statuses
-      - paasbetaapplications
-      - paasbetastatuses
       - statuses
     verbs:
       - create
@@ -55,7 +53,6 @@ rules:
       - pods
       - resourcequotas
       - services
-      - thirdpartyresources
     verbs:
       - create
       - delete
@@ -74,6 +71,7 @@ rules:
       - get
       - list
       - update
+
 ---
 kind: ClusterRoleBinding
 {{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
@@ -87,6 +85,31 @@ subjects:
 - kind: Group
   name: system:serviceaccounts
   apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: fiaas-controller
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+
+---
+kind: ClusterRoleBinding
+{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ .Values.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: fiaas-controller


### PR DESCRIPTION
give skipper its own service account

currently skipper is using the default service account. Since it makes calls to the apiserver, it should be identifying itself using serviceaccounts. This PR modifies the helm chart to assign a serviceaccount to the skipper pod as well as a clusterrolebinding which assigns the fiaas-control clusterrole to the skipper serviceaccount in an explicit manner.

This PR is the first step in moving towards more explicit RBAC control over FIAAS apps. Next steps will include ceasing the practice of assinging the fiaas-controler clusterrole to every service account in every namespace.