### PR TITLE
Disable autoUpdate by default, improve documentation

### DIFF
--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -36,7 +36,7 @@ statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed
 addFiaasDeployDaemonConfigmap: false
 fiaasDeployDaemonTag: stable
-autoUpdate: true
+autoUpdate: false
 service:
   type: ClusterIP
 fiaas_override_yaml: null


### PR DESCRIPTION
I think `autoUpdate` is something most setups of skipper probably don't want enabled, so I think it would be a good idea for that flag to default to false. Any thoughts on this change in default values?

I've made an attempt at improving the parts of the readme covering how skipper works, and also added some documentation about how the latest and stable tags work. (I originally just wanted to make the documentation a bit clearer, but as I got to the part covering automatic updates, I started thinking it might be best if that feature was disabled by default too).