### PR TITLE
Temporarily disable ARM builds

### DIFF
--- a/bin/docker_build
+++ b/bin/docker_build
@@ -9,7 +9,10 @@ CACHE_DIR=${PIP_CACHE_DIR:-~/.cache/pip}
 mkdir -p build
 
 if [[ "${CI:-}" == "true" ]]; then
-  PLATFORMS=linux/arm,linux/arm64,linux/amd64
+  # Disabling arm builds for the time being - ARM builds are taking too long and exceed the limit of a build job in travis
+  # For additional context, see https://kubernetes.slack.com/archives/CNASTE7CP/p1622055933020700
+  #PLATFORMS=linux/arm,linux/arm64,linux/amd64
+  PLATFORMS=linux/amd64
 else
   PLATFORMS=linux/amd64
 fi

--- a/bin/docker_push
+++ b/bin/docker_push
@@ -10,7 +10,7 @@ if [[ "${CI:-}" == "true" ]]; then
   docker buildx build --pull \
     --tag "${IMAGE_NAME}:latest" \
     --tag "${DOCKER_IMAGE}" \
-    --platform=linux/arm,linux/arm64,linux/amd64 \
+    --platform=linux/amd64 \
     --push .
     echo "Pushed image ${DOCKER_IMAGE}"
 fi


### PR DESCRIPTION
Disabling ARM builds for now due to taking a long time and making the CI job take too long and being terminated by Travis.

When executing https://github.com/fiaas/skipper/issues/107, it should be perfectly fine to re-enable multi-arch builds