### PR TITLE
give fdd its own rbac resources

### DIFF
--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,7 +57,7 @@ def _create_pod_spec(args, channel, namespace, spec_config):
         command=["fiaas-deploy-daemon-bootstrap"] + args,
         resources=_create_resource_requirements(namespace, spec_config)
     )
-    pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")
+    pod_spec = PodSpec(containers=[container], serviceAccountName="fiaas-deploy-daemon", restartPolicy="Never")
     return pod_spec
 
 

--- a/helm/fiaas-skipper/Chart.yaml
+++ b/helm/fiaas-skipper/Chart.yaml
@@ -17,4 +17,4 @@ apiVersion: v1
 description: Skipper controls deployment and updates of FIAAS components
 name: fiaas-skipper
 home: https://github.com/fiaas/skipper
-version: 0.2.0
+version: 0.1.0

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -175,4 +175,94 @@ roleRef:
   name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io
 
+
+{{- range .Values.rbac.fiaasDeployDaemonNamespaces }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fiaas-deploy-daemon
+  namespace: {{ . }}
+
+---
+kind: Role
+{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: fiaas-deploy-daemon
+  namespace: {{ . }}
+rules:
+  - apiGroups:
+      - fiaas.schibsted.io
+      - schibsted.io
+    resources:
+      - applications
+      - application-statuses
+      - statuses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - "" # "" indicates the core API group
+      - apps
+      - autoscaling
+      - apiextensions
+      - apiextensions.k8s.io
+      - extensions
+    resources:
+      - configmaps
+      - customresourcedefinitions
+      - deployments
+      - horizontalpodautoscalers
+      - ingresses
+      - pods
+      - resourcequotas
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - "" # "" indicates the core API group
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+
+---
+kind: RoleBinding
+{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: fiaas-deploy-daemon
+  namespace: {{ . }}
+subjects:
+- kind: ServiceAccount
+  name: fiaas-deploy-daemon
+  namespace: {{ . }}
+roleRef:
+  kind: ClusterRole
+  name: fiaas-deploy-deamon
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end }}
+
 {{- end }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -32,6 +32,9 @@ baseurl: 'https://fiaas.github.io/releases'
 annotations: {}
 rbac:
   enabled: false
+  # namespaces in which to create rbac resources for fiaas deploy daemon
+  fiaasDeployDaemonNamespaces:
+  - default
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed
 addFiaasDeployDaemonConfigmap: false


### PR DESCRIPTION
The majority of this PR modifies Skipper's helm chart to create RBAC resources for fiaas-deploy-daemon. This makes it so that when FDD is making calls against the Kubernetes API, it will identify itself as fiaas-deploy-daemon rather than as the default service account.

In addition, Skipper will now assign the fiaas-deploy-daemon service account to the fdd bootstrap container when creating it.

This is part of the effort to introduce per-app-service-accounts, as seen in FDD's PR's.