### PR TITLE
Fix content-type header in the api requests.

### DIFF
--- a/fiaas_skipper/web/api.py
+++ b/fiaas_skipper/web/api.py
@@ -38,7 +38,9 @@ deploy_histogram = request_histogram.labels("deploy")
 @status_histogram.time()
 def status():
     deployment_statuses = api.status()
-    return make_response(json.dumps(deployment_statuses, default=_encode), 200)
+    response = make_response(json.dumps(deployment_statuses, default=_encode), 200)
+    response.headers['Content-Type'] = 'application/json'
+    return response
 
 
 def _encode(obj):
@@ -65,7 +67,9 @@ def deploy():
     force_bootstrap = _force_bootstrap(request)
     threading.Thread(target=_deploy, kwargs={'namespaces': namespaces,
                                              'force_bootstrap': force_bootstrap}).start()
-    return make_response('', 200)
+    response = make_response('', 200)
+    response.headers['Content-Type'] = 'application/json'
+    return response
 
 
 def _deploy(namespaces=None, force_bootstrap=False):

--- a/tests/fiaas_skipper/web/test_api.py
+++ b/tests/fiaas_skipper/web/test_api.py
@@ -68,13 +68,16 @@ class TestApi(object):
             "version": "fiaas/fiaas-deploy-daemon:123",
             "channel": "stable"
         }]
+        assert response.headers['Content-Type'] == 'application/json'
 
     def test_deploy(self, app, deployer):
         response = app.post('/api/deploy')
         assert response.status_code == 200
+        assert response.headers['Content-Type'] == 'application/json'
         deployer.deploy.assert_called_with(force_bootstrap=False, namespaces=None)
 
     def test_deploy_force_bootstrap(self, app, deployer):
         response = app.post('/api/deploy', json={'force_bootstrap': True, 'namespaces': ['test1']})
         assert response.status_code == 200
+        assert response.headers['Content-Type'] == 'application/json'
         deployer.deploy.assert_called_with(force_bootstrap=True, namespaces=['test1'])


### PR DESCRIPTION
API requests return json, and not html, so have content-type reflect that.

I considered also doing it via jsonify(), but that seemed lesss clean.