### PR TITLE
Improvement: helm: allow configuring releaseChannelMetadata and releaseChannelMetadataSpec

### DIFF
--- a/helm/fiaas-skipper/templates/config_map.yaml
+++ b/helm/fiaas-skipper/templates/config_map.yaml
@@ -32,6 +32,16 @@ data:
     {{with .Values.debug}}debug: true{{end}}
     {{with .Values.statusUpdateInterval}}status-update-interval: {{.}}{{end}}
     {{with not .Values.autoUpdate}}disable-autoupdate: true{{end}}
+    {{with .Values.releaseChannelMetadata -}}release-channel-metadata:
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
+    {{ end -}}
+    {{with .Values.releaseChannelMetadataSpec -}}release-channel-metadata-spec:
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
+    {{ end -}}
   fiaas_override.yaml: |-
 {{ if .Values.fiaas_override_yaml -}}
 {{ .Values.fiaas_override_yaml | indent 4 }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -37,6 +37,16 @@ statusUpdateInterval: 30
 addFiaasDeployDaemonConfigmap: false
 fiaasDeployDaemonTag: stable
 autoUpdate: false
+# releaseChannelMetadata: Useful if you have autoUpdate off, and want to hardcode which fiaas release to use.
+# Metadata for the stable channel can be found by default at: https://fiaas.github.io/releases/fiaas-deploy-daemon/stable.json
+releaseChannelMetadata: {}
+#releaseChannelMetadata:
+#  image: "fiaas/fiaas-deploy-daemon:20210902130955-8d6e989"
+#  build: "https://fiaas.semaphoreci.com/jobs/8ac837af-cd8d-4ccc-be3f-a0b692f19c00"
+#  commit: "https://github.com/fiaas/fiaas-deploy-daemon/commit/8d6e9897f140f73bc05b7b34bc484250cf9839b8"
+#  spec: "https://fiaas.github.io/releases/artifacts/20210902130955-8d6e989/fiaas.yml"
+#  updated: "2021-09-22T08:24:21+00:00"
+releaseChannelMetadataSpec: {}
 service:
   type: ClusterIP
 fiaas_override_yaml: null


### PR DESCRIPTION
With this we can configure skipper to deploy a configurable/pre-determined version of fiaas,
independent of the upstream release cycle.