### PR TITLE
Handle SIGTERM and SIGINT gracefully

### DIFF
--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -17,8 +17,6 @@
 
 from __future__ import absolute_import
 
-import signal
-
 from gevent import monkey
 
 monkey.patch_all()  # NOQA
@@ -26,6 +24,7 @@ monkey.patch_all()  # NOQA
 import json
 import logging
 import os
+import signal
 
 import yaml
 from k8s import config as k8s_config
@@ -50,6 +49,8 @@ class ExitOnSignal(Exception):
 
 
 def signal_handler(signum, frame):
+    signame = signal.Signals(signum).name
+    LOG.fatal(f"Received signal {signame}({signum}), exiting")
     raise ExitOnSignal()
 
 

--- a/fiaas_skipper/__init__.py
+++ b/fiaas_skipper/__init__.py
@@ -50,7 +50,7 @@ class ExitOnSignal(Exception):
 
 def signal_handler(signum, frame):
     signame = signal.Signals(signum).name
-    LOG.fatal(f"Received signal {signame}({signum}), exiting")
+    LOG.critical(f"Received signal {signame}({signum}), exiting")
     raise ExitOnSignal()
 
 


### PR DESCRIPTION
Fixes #103

This is untested, in the sense that I haven't tested skipper with these changes, but I have done this in other applications running on kubernetes, and it behaves as you would expect.

Obviously, this would be a bad idea if the application needs to perform some cleanup on SIGTERM/SIGINT, but I'm fairly sure skipper doesn't need that (and if so, it isn't doing it as it is).
