### PR TITLE
conditionally enable service-account-per-app in bootstrap pod

### DIFF
--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -46,8 +46,10 @@ class BarePodBootstrapper(object):
             pass
         args = self._cmd_args
         if deployment_config.enable_service_account_per_app:
-            args.append("--enable-service-account-per-app")
-        pod_spec = _create_pod_spec(args, channel, namespace, spec_config, rbac=rbac)
+            pod_spec = _create_pod_spec(args + ["--enable-service-account-per-app"],
+                                        channel, namespace, spec_config, rbac=rbac)
+        else:
+            pod_spec = _create_pod_spec(args, channel, namespace, spec_config, rbac=rbac)
         pod_metadata = _create_pod_metadata(namespace, spec_config)
         pod = Pod(metadata=pod_metadata, spec=pod_spec)
         pod.save()

--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -44,7 +44,10 @@ class BarePodBootstrapper(object):
             Pod.delete(name=BOOTSTRAP_POD_NAME, namespace=namespace)
         except NotFound:
             pass
-        pod_spec = _create_pod_spec(self._cmd_args, channel, namespace, spec_config, rbac=rbac)
+        args = self._cmd_args
+        if deployment_config.enable_service_account_per_app:
+            args.append("--enable-service-account-per-app")
+        pod_spec = _create_pod_spec(args, channel, namespace, spec_config, rbac=rbac)
         pod_metadata = _create_pod_metadata(namespace, spec_config)
         pod = Pod(metadata=pod_metadata, spec=pod_spec)
         pod.save()

--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -57,7 +57,8 @@ def _create_pod_spec(args, channel, namespace, spec_config, rbac=False):
     container = Container(
         name="fiaas-deploy-daemon-bootstrap",
         image=channel.metadata['image'],
-        command=["fiaas-deploy-daemon-bootstrap"] + args,
+        command=["fiaas-deploy-daemon-bootstrap"],
+        args=args,
         resources=_create_resource_requirements(namespace, spec_config)
     )
     pod_spec = PodSpec(containers=[container], serviceAccountName="default", restartPolicy="Never")

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,8 @@ from k8s.models.configmap import ConfigMap
 
 LOG = logging.getLogger(__name__)
 
-DeploymentConfig = collections.namedtuple('DeploymentConfig', ['name', 'namespace', 'tag'])
+DeploymentConfig = collections.namedtuple(
+    'DeploymentConfig', ['name', 'namespace', 'tag', 'service_account_per_app'])
 
 
 class Cluster(object):
@@ -31,6 +32,17 @@ class Cluster(object):
         res = []
         configmaps = ConfigMap.find(name, namespace)
         for c in configmaps:
-            tag = c.data['tag'] if 'tag' in c.data else 'stable'
-            res.append(DeploymentConfig(name=name, namespace=c.metadata.namespace, tag=tag))
+            tag = 'stable'
+            sa_per_app = False
+            for k, v in c.data.items():
+                if k == 'tag':
+                    tag = v
+                elif k == 'enable-service-account-per-app':
+                    sa_per_app = v
+            res.append(DeploymentConfig(
+                name=name,
+                namespace=c.metadata.namespace,
+                tag=tag,
+                service_account_per_app=sa_per_app,
+            ))
         return res

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -23,7 +23,7 @@ from k8s.models.configmap import ConfigMap
 LOG = logging.getLogger(__name__)
 
 DeploymentConfig = collections.namedtuple(
-    'DeploymentConfig', ['name', 'namespace', 'tag', 'service_account_per_app'])
+    'DeploymentConfig', ['name', 'namespace', 'tag', 'enable_service_account_per_app'])
 
 
 class Cluster(object):
@@ -43,6 +43,6 @@ class Cluster(object):
                 name=name,
                 namespace=c.metadata.namespace,
                 tag=tag,
-                service_account_per_app=sa_per_app,
+                enable_service_account_per_app=sa_per_app,
             ))
         return res

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -17,6 +17,7 @@
 
 import collections
 import logging
+import yaml
 
 from k8s.models.configmap import ConfigMap
 
@@ -33,7 +34,10 @@ class Cluster(object):
         configmaps = ConfigMap.find(name, namespace)
         for c in configmaps:
             tag = c.data.get('tag', 'stable')
-            sa_per_app = c.data.get('enable-service-account-per-app', False)
+
+            cluster_config = yaml.safe_load(c.data.get('cluster_config.yaml', "{}"))
+            sa_per_app = cluster_config.get('enable-service-account-per-app', False)
+
             res.append(DeploymentConfig(
                 name=name,
                 namespace=c.metadata.namespace,

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -32,13 +32,8 @@ class Cluster(object):
         res = []
         configmaps = ConfigMap.find(name, namespace)
         for c in configmaps:
-            tag = 'stable'
-            sa_per_app = False
-            for k, v in c.data.items():
-                if k == 'tag':
-                    tag = v
-                elif k == 'enable-service-account-per-app':
-                    sa_per_app = v
+            tag = c.data.get('tag', 'stable')
+            sa_per_app = c.data.get('enable-service-account-per-app', False)
             res.append(DeploymentConfig(
                 name=name,
                 namespace=c.metadata.namespace,

--- a/tests/fiaas_skipper/deploy/crd/test_deployer.py
+++ b/tests/fiaas_skipper/deploy/crd/test_deployer.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ class TestCrdDeployer(object):
     def cluster(self):
         cluster = mock.NonCallableMagicMock(name="cluster")
         cluster.find_deployment_configs.return_value = (
-            DeploymentConfig("testapp", "test1", "stable"),
+            DeploymentConfig("testapp", "test1", "stable", False),
         )
         return cluster
 

--- a/tests/fiaas_skipper/deploy/test_bootstrap.py
+++ b/tests/fiaas_skipper/deploy/test_bootstrap.py
@@ -99,7 +99,7 @@ class TestBarePodBootstrapper():
             [self.create_resourcequota(namespace, resourcequota_spec)] if resourcequota_spec else []
         bootstrapper = BarePodBootstrapper()
         channel = ReleaseChannel(None, None, {'image': 'example.com/image:tag'}, None)
-        deployment_config = DeploymentConfig('foo', namespace, 'latest')
+        deployment_config = DeploymentConfig('foo', namespace, 'latest', False)
         expected_pod = {
             'metadata': {
                 'name': 'fiaas-deploy-daemon-bootstrap',
@@ -113,7 +113,7 @@ class TestBarePodBootstrapper():
                 'containers': [{
                     'name': 'fiaas-deploy-daemon-bootstrap',
                     'image': 'example.com/image:tag',
-                    'args': [],
+                    'args': ["--enable-service-account-per-app"],
                     'ports': [],
                     'env': [],
                     'envFrom': [],

--- a/tests/fiaas_skipper/deploy/test_bootstrap.py
+++ b/tests/fiaas_skipper/deploy/test_bootstrap.py
@@ -71,35 +71,35 @@ class TestBarePodBootstrapper():
         spec = ResourceQuotaSpec.from_dict(resourcequota_spec)
         return ResourceQuota(metadata=metadata, spec=spec)
 
-    @pytest.mark.parametrize("namespace,resourcequota_spec,resources,spec_config,rbac", [
-        ("default", None, spec_config()['resources'], spec_config(), False),
-        ("default", None, spec_config()['resources'], spec_config(), True),
-        ("other-namespace", None, spec_config()['resources'], spec_config(), False),
-        ("default", None, OVERRIDE_ALL_RESOURCES, spec_config(resources=OVERRIDE_ALL_RESOURCES), False),
-        ("other-namespace", None, OVERRIDE_ALL_RESOURCES, spec_config(resources=OVERRIDE_ALL_RESOURCES), False),
-        ("other-namespace", None, spec_config()['resources'], spec_config(), False),
-        ("default", ONLY_BEST_EFFORT_ALLOWED, None, spec_config(), False),
-        ("other-namespace", ONLY_BEST_EFFORT_ALLOWED, None, spec_config(), False),
+    @pytest.mark.parametrize("namespace,resourcequota_spec,resources,spec_config,rbac,sa_per_app", [
+        ("default", None, spec_config()['resources'], spec_config(), False, False),
+        ("default", None, spec_config()['resources'], spec_config(), True, True),
+        ("other-namespace", None, spec_config()['resources'], spec_config(), False, False),
+        ("default", None, OVERRIDE_ALL_RESOURCES, spec_config(resources=OVERRIDE_ALL_RESOURCES), False, False),
+        ("other-namespace", None, OVERRIDE_ALL_RESOURCES, spec_config(resources=OVERRIDE_ALL_RESOURCES), False, False),
+        ("other-namespace", None, spec_config()['resources'], spec_config(), False, False),
+        ("default", ONLY_BEST_EFFORT_ALLOWED, None, spec_config(), False, False),
+        ("other-namespace", ONLY_BEST_EFFORT_ALLOWED, None, spec_config(), False, False),
         ("default", BEST_EFFORT_NOT_ALLOWED, spec_config()['resources'],
-            spec_config(), False),
+            spec_config(), False, False),
         ("other-namespace", BEST_EFFORT_NOT_ALLOWED, spec_config()['resources'],
-            spec_config(), False),
+            spec_config(), False, False),
         ("default", ONLY_BEST_EFFORT_ALLOWED, None,
-            spec_config(resources=OVERRIDE_ALL_RESOURCES), False),
+            spec_config(resources=OVERRIDE_ALL_RESOURCES), False, False),
         ("other-namespace", ONLY_BEST_EFFORT_ALLOWED, None,
-            spec_config(resources=OVERRIDE_ALL_RESOURCES), False),
+            spec_config(resources=OVERRIDE_ALL_RESOURCES), False, False),
         ("default", BEST_EFFORT_NOT_ALLOWED, OVERRIDE_ALL_RESOURCES,
-            spec_config(OVERRIDE_ALL_RESOURCES), False),
+            spec_config(OVERRIDE_ALL_RESOURCES), False, False),
         ("other-namespace", BEST_EFFORT_NOT_ALLOWED, OVERRIDE_ALL_RESOURCES,
-            spec_config(OVERRIDE_ALL_RESOURCES), False),
+            spec_config(OVERRIDE_ALL_RESOURCES), False, False),
     ])
     def test_bootstrap(self, post, delete, resourcequota_list, namespace,
-                       resourcequota_spec, resources, spec_config, rbac):
+                       resourcequota_spec, resources, spec_config, rbac, sa_per_app):
         resourcequota_list.return_value = \
             [self.create_resourcequota(namespace, resourcequota_spec)] if resourcequota_spec else []
         bootstrapper = BarePodBootstrapper()
         channel = ReleaseChannel(None, None, {'image': 'example.com/image:tag'}, None)
-        deployment_config = DeploymentConfig('foo', namespace, 'latest', True)
+        deployment_config = DeploymentConfig('foo', namespace, 'latest', sa_per_app)
         expected_pod = {
             'metadata': {
                 'name': 'fiaas-deploy-daemon-bootstrap',
@@ -113,7 +113,7 @@ class TestBarePodBootstrapper():
                 'containers': [{
                     'name': 'fiaas-deploy-daemon-bootstrap',
                     'image': 'example.com/image:tag',
-                    'args': ["--enable-service-account-per-app"],
+                    'args': [],
                     'ports': [],
                     'env': [],
                     'envFrom': [],
@@ -132,6 +132,8 @@ class TestBarePodBootstrapper():
             expected_pod['spec']['containers'][0]['resources'] = resources
         if rbac:
             expected_pod['spec']['serviceAccountName'] = 'fiaas-deploy-daemon'
+        if sa_per_app:
+            expected_pod['spec']['containers'][0]['args'].append('--enable-service-account-per-app')
 
         with mock.patch('pyrfc3339.parse'):
             bootstrapper(deployment_config, channel, spec_config=spec_config, rbac=rbac)

--- a/tests/fiaas_skipper/deploy/test_bootstrap.py
+++ b/tests/fiaas_skipper/deploy/test_bootstrap.py
@@ -99,7 +99,7 @@ class TestBarePodBootstrapper():
             [self.create_resourcequota(namespace, resourcequota_spec)] if resourcequota_spec else []
         bootstrapper = BarePodBootstrapper()
         channel = ReleaseChannel(None, None, {'image': 'example.com/image:tag'}, None)
-        deployment_config = DeploymentConfig('foo', namespace, 'latest', False)
+        deployment_config = DeploymentConfig('foo', namespace, 'latest', True)
         expected_pod = {
             'metadata': {
                 'name': 'fiaas-deploy-daemon-bootstrap',

--- a/tests/fiaas_skipper/deploy/test_cluster.py
+++ b/tests/fiaas_skipper/deploy/test_cluster.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,17 +26,20 @@ from fiaas_skipper.deploy.cluster import Cluster
 NAME = "deployment_target"
 
 
-def _create_configmap(namespace, tag=None):
+def _create_configmap(namespace, tag=None, cluster_config=None):
     metadata = ObjectMeta(name=NAME, namespace=namespace)
     data = {}
+    if cluster_config:
+        data["cluster_config.yaml"] = cluster_config
     if tag:
         data["tag"] = tag
     return ConfigMap(metadata=metadata, data=data)
 
 
-def _assert_deployment_config(result, namespace, tag):
+def _assert_deployment_config(result, namespace, tag, enable_service_account_per_app):
     assert namespace == result.namespace
     assert tag == result.tag
+    assert enable_service_account_per_app == result.enable_service_account_per_app
 
 
 class TestCluster(object):
@@ -44,9 +47,9 @@ class TestCluster(object):
     def config_map_find(self):
         with mock.patch("k8s.models.configmap.ConfigMap.find") as finder:
             finder.return_value = (
-                _create_configmap("ns1", "stable"),
-                _create_configmap("ns2", "latest"),
-                _create_configmap("ns3"),
+                _create_configmap("ns1", "stable", cluster_config="enable-service-account-per-app: true"),
+                _create_configmap("ns2", "latest", cluster_config="log-format: json"),
+                _create_configmap("ns3", cluster_config="log-format: json\nenable-service-account-per-app: true"),
                 _create_configmap("ns4", "latest"),
                 _create_configmap("ns5", "stable"),
             )
@@ -58,6 +61,6 @@ class TestCluster(object):
         results = cluster.find_deployment_configs(NAME)
 
         assert len(results) == 5
-        _assert_deployment_config(results[0], "ns1", "stable")
-        _assert_deployment_config(results[1], "ns2", "latest")
-        _assert_deployment_config(results[2], "ns3", "stable")
+        _assert_deployment_config(results[0], "ns1", "stable", True)
+        _assert_deployment_config(results[1], "ns2", "latest", False)
+        _assert_deployment_config(results[2], "ns3", "stable", True)

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -69,8 +69,8 @@ class TestDeployer(object):
     def cluster(self):
         cluster = mock.NonCallableMagicMock(name="cluster")
         cluster.find_deployment_configs.return_value = (
-            DeploymentConfig("test1", "test1", "stable"),
-            DeploymentConfig("test2", "test2", "stable"),
+            DeploymentConfig("test1", "test1", "stable", False),
+            DeploymentConfig("test2", "test2", "stable", False),
         )
         return cluster
 

--- a/tests/fiaas_skipper/deploy/test_deploy.py
+++ b/tests/fiaas_skipper/deploy/test_deploy.py
@@ -118,12 +118,12 @@ class TestStatusTracker(object):
     def cluster(self):
         cluster = mock.NonCallableMagicMock(name="cluster")
         cluster.find_deployment_configs.return_value = (
-            DeploymentConfig("fdd", "ns1", "stable"),
-            DeploymentConfig("fdd", "ns2", "latest"),
-            DeploymentConfig("fdd", "ns3", "stable"),
-            DeploymentConfig("fdd", "ns4", "latest"),
-            DeploymentConfig("fdd", "ns5", "stable"),
-            DeploymentConfig("fdd", "ns6", "stable"),
+            DeploymentConfig("fdd", "ns1", "stable", False),
+            DeploymentConfig("fdd", "ns2", "latest", False),
+            DeploymentConfig("fdd", "ns3", "stable", False),
+            DeploymentConfig("fdd", "ns4", "latest", False),
+            DeploymentConfig("fdd", "ns5", "stable", False),
+            DeploymentConfig("fdd", "ns6", "stable", False),
         )
         return cluster
 


### PR DESCRIPTION
the bootstrap pod, when deployed by skipper, doesn't currently heed the enable-service-account-per-app field in the FDD configmap. This behaviour is implemented by this PR.