### PR TITLE
Fix status view; /api/status returns json, don't parse it

### DIFF
--- a/fiaas_skipper/web/static/skipper.js
+++ b/fiaas_skipper/web/static/skipper.js
@@ -1,12 +1,12 @@
 
 // Copyright 2017-2019 The FIAAS Authors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ function getStatus() {
     type: "GET",
     url: "/api/status",
     success: function(data) {
-      var json = $.parseJSON(data);
+      var json = data;
       var statusmap = {
        "OK": "success",
        "UNKNOWN": "warning",


### PR DESCRIPTION
Fixes #126.

I think this is a regression after #117 changed the content-type of
/api/status to return application/json. The client side (js) treats the
response from /api/status as a string containing json because the content
type used to be text/html (which was also wrong), but now it gets json
. When the client tries to parse the response, parseJSON raises a
exception because the response is already json. 
Skip the parsing and just use the response object directly as it is json.