### PR TITLE
Use built-in support for k8s client in-cluster config

### DIFF
--- a/fiaas_skipper/config.py
+++ b/fiaas_skipper/config.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import
 
 import logging
-import os
 from argparse import Namespace
 
 import configargparse
@@ -34,7 +33,6 @@ class Configuration(Namespace):
         super(Configuration, self).__init__(**kwargs)
         self._logger = logging.getLogger(__name__)
         self._parse_args(args)
-        self._resolve_api_config()
 
     def _parse_args(self, args):
         parser = configargparse.ArgParser(auto_env_var_prefix="",
@@ -78,13 +76,6 @@ class Configuration(Namespace):
         client_cert_parser.add_argument("--client-cert", help="Client certificate to use", default=None)
         client_cert_parser.add_argument("--client-key", help="Client certificate key to use", default=None)
         parser.parse_args(args, namespace=self)
-
-    def _resolve_api_config(self):
-        token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        if os.path.exists(token_file):
-            with open(token_file) as fobj:
-                self.api_token = fobj.read().strip()
-            self.api_cert = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
     def __repr__(self):
         return "Configuration({})".format(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def version():
 
 
 GENERIC_REQ = [
-    "k8s==0.19.0",
+    "k8s==0.20.0",
     "ConfigArgParse==0.13.0",
     "six==1.12.0",
     "PyYAML==3.13",


### PR DESCRIPTION
Use built-in support in fiaas/k8s for in-cluster config for the Kubernetes client. This  regularly refreshes the service account token from disk, which is needed for running on Kubernetes 1.21+ with BoundServiceAccountTokenVolume and time-bound tokens. The behavior should be the same as implemented for fiaas-deploy-daemon implemented in https://github.com/fiaas/fiaas-deploy-daemon/pull/166.

closes: #127