### PR TITLE
allow networking/v1 ingress in chart

### DIFF
--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: {{ if .Values.ingress.useNetworkingV1 }}networking.k8s.io/v1{{ else }}extensions/v1beta1{{ end }}
 kind: Ingress
 metadata:
   labels:
@@ -47,6 +46,15 @@ spec:
     http:
       paths:
       - backend:
+{{- if .Values.ingress.useNetworkingV1 }}
+          service:
+            name: "{{ .Values.name }}"
+            port:
+              number: 5000
+        path: /
+        pathType: ImplementationSpecific
+{{- else }}
           serviceName: "{{ .Values.name }}"
           servicePort: 5000
         path: /
+{{- end }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -19,6 +19,7 @@ image:
   tag: "latest"
   pullPolicy: Always
 ingress:
+  useNetworkingV1: false
   fqdn: fiaas-skipper.yourcluster.local
   enableTLS: true
   annotations: {}


### PR DESCRIPTION
the ingress deployed in skipper's helm chart for accessing its web interface is deployed using the extensions/v1beta1 api. The networking.k8s.io/v1 api should be optionally used for this purpose.