### PR TITLE
conditionally enable networking/v1 ingress in bootstrap pod

### DIFF
--- a/fiaas_skipper/deploy/bootstrap.py
+++ b/fiaas_skipper/deploy/bootstrap.py
@@ -46,10 +46,10 @@ class BarePodBootstrapper(object):
             pass
         args = self._cmd_args
         if deployment_config.enable_service_account_per_app:
-            pod_spec = _create_pod_spec(args + ["--enable-service-account-per-app"],
-                                        channel, namespace, spec_config, rbac=rbac)
-        else:
-            pod_spec = _create_pod_spec(args, channel, namespace, spec_config, rbac=rbac)
+            args.append("--enable-service-account-per-app")
+        if deployment_config.use_networkingv1_ingress:
+            args.append("--use-networkingv1-ingress")
+        pod_spec = _create_pod_spec(args, channel, namespace, spec_config, rbac=rbac)
         pod_metadata = _create_pod_metadata(namespace, spec_config)
         pod = Pod(metadata=pod_metadata, spec=pod_spec)
         pod.save()

--- a/fiaas_skipper/deploy/cluster.py
+++ b/fiaas_skipper/deploy/cluster.py
@@ -24,7 +24,7 @@ from k8s.models.configmap import ConfigMap
 LOG = logging.getLogger(__name__)
 
 DeploymentConfig = collections.namedtuple(
-    'DeploymentConfig', ['name', 'namespace', 'tag', 'enable_service_account_per_app'])
+    'DeploymentConfig', ['name', 'namespace', 'tag', 'enable_service_account_per_app', 'use_networkingv1_ingress'])
 
 
 class Cluster(object):
@@ -37,11 +37,13 @@ class Cluster(object):
 
             cluster_config = yaml.safe_load(c.data.get('cluster_config.yaml', "{}"))
             sa_per_app = cluster_config.get('enable-service-account-per-app', False)
+            networkingv1_ingress = cluster_config.get('use-networkingv1-ingress', False)
 
             res.append(DeploymentConfig(
                 name=name,
                 namespace=c.metadata.namespace,
                 tag=tag,
                 enable_service_account_per_app=sa_per_app,
+                use_networkingv1_ingress=networkingv1_ingress,
             ))
         return res


### PR DESCRIPTION
When `use-networkingv1-ingress` is enabled in the fiaas-deploy-daemon configmap, skipper should also run the bootstrap pod with that flag enabled.