### PR TITLE
Always use v1 RBAC API for clusterrole + clusterrolebindings (drops compatibility with Kubernetes 1.7 and earlier)

### DIFF
--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -16,11 +16,7 @@
 {{- if .Values.rbac.enabled }}
 ---
 kind: ClusterRole
-{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: fiaas-controller
 rules:
@@ -76,11 +72,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: fiaas-controller
 subjects:
@@ -100,11 +92,7 @@ metadata:
 
 ---
 kind: ClusterRole
-{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: {{ .Values.name }}
 rules:
@@ -159,11 +147,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: {{ .Values.name }}
 subjects:


### PR DESCRIPTION
When installing this chart on GKE, ClusterRole and ClusterRoleBindings are always installed using the rbac.authorization.k8s.io/v1beta1 API version. This seems to happen because the conditional which checks Kubernetes version with `semverCompare` always renders as false in GKE because the Kubernetes version in GKE is usually major.minor.patch-gke.release (e.g. 1.20.12-gke.1500). `semverCompare` apparently can't compare that version pattern.

rbac.authorization.k8s.io/v1beta1 is removed in Kubernetes 1.22, so the chart must be fixed to install cleanly on GKE 1.22+. Rather than trying to fix the conditional I think it should be fine to always use rbac.authorization.k8s.io/v1, as this API version is available since Kubernetes 1.8.

This means the next release of the skipper chart will not install on Kubernetes < 1.7 and earlier. To install skipper on 1.7 or earlier, use chart version 0.1.53 (the currently most recent release).