### PR TITLE
allow opting out from fiaas-controller role

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -11,7 +11,7 @@ ignore-paths:
   - .tox
   - .cachedocs
 
-pep8:
+pycodestyle:
   options:
     max-line-length: 120
   disable:
@@ -35,5 +35,5 @@ frosted:
 vulture:
   run: false
 
-pep257:
+pydocstyle:
   run: false

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 {{- if .Values.rbac.enabled }}
+
+{{- if .Values.rbac.enableFIAASController }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -83,6 +85,7 @@ roleRef:
   kind: ClusterRole
   name: fiaas-controller
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 
 ---
 apiVersion: v1

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -40,6 +40,7 @@ baseurl: 'https://fiaas.github.io/releases'
 annotations: {}
 rbac:
   enabled: false # create RBAC resources giving Skipper the permissions it needs
+  enableFIAASController: true # enable the fiaas-controller clusterrole/clusterrolebinding, giving all service accounts great permissions
 manageRBAC: false # have Skipper create RBAC resources for any FDD it deploys
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed


### PR DESCRIPTION
Skipper's Helm chart still includes an RBAC clusterRole/clusterRoleBinding which gives huge permissions to all service accounts in the cluster. Thus any pod with a serviceAccountToken is able to perform almost unlimited read/write calls to the Kubernetes API. This PR allows one to turn this off in the Helm chart.