### PR TITLE
create fdd clusterrole for crd creation/updating

### DIFF
--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -162,4 +162,37 @@ roleRef:
   name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io
 
+---
+## this must be created so FDD is able to create/update the CRD on startup
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fiaas-deploy-daemon
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - update
+
+---
+## this must be created so FDD is able to create/update the CRD on startup
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fiaas-deploy-daemon
+roleRef:
+  kind: ClusterRole
+  name: fiaas-deploy-daemon
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+{{- range .Values.rbac.fddClusterRoleNamespaces }}
+- kind: ServiceAccount
+  name: fiaas-deploy-daemon
+  namespace: {{ . }}
+{{- end }}
+
 {{- end }}

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -189,7 +189,7 @@ roleRef:
   name: fiaas-deploy-daemon
   apiGroup: rbac.authorization.k8s.io
 subjects:
-{{- range .Values.rbac.fddClusterRoleNamespaces }}
+{{- range .Values.rbac.fddClusterRole.namespaces }}
 - kind: ServiceAccount
   name: fiaas-deploy-daemon
   namespace: {{ . }}

--- a/helm/fiaas-skipper/templates/rbac.yaml
+++ b/helm/fiaas-skipper/templates/rbac.yaml
@@ -162,6 +162,8 @@ roleRef:
   name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io
 
+
+{{- if .Values.rbac.fddClusterRole.enabled }}
 ---
 ## this must be created so FDD is able to create/update the CRD on startup
 kind: ClusterRole
@@ -189,10 +191,11 @@ roleRef:
   name: fiaas-deploy-daemon
   apiGroup: rbac.authorization.k8s.io
 subjects:
-{{- range .Values.rbac.fddClusterRole.namespaces }}
-- kind: ServiceAccount
-  name: fiaas-deploy-daemon
-  namespace: {{ . }}
+  {{- range .Values.rbac.fddClusterRole.namespaces }}
+  - kind: ServiceAccount
+    name: fiaas-deploy-daemon
+    namespace: {{ . }}
+  {{- end }}
 {{- end }}
 
 {{- end }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -41,10 +41,17 @@ annotations: {}
 rbac:
   enabled: false # create RBAC resources giving Skipper the permissions it needs
   enableFIAASController: true # enable the fiaas-controller clusterrole/clusterrolebinding, giving all service accounts great permissions
-  # Bind the fiaas-deploy-daemon clusterrole to the fiaas-deploy-daemon service account in these namespaces.
-  # This is necessary for FDD to be able to create/update the CRD's on startup.
+
+  # Bind the fiaas-deploy-daemon clusterrole to the fiaas-deploy-daemon service
+  # account in these namespaces. This is necessary for FDD to be able to
+  # create/update the CRD's on startup. If rbac.enableFIAASController == true,
+  # or if crd-creation is disabled, there is no need to enable
+  # rbac.fddClusterRole. These permissions can alternatively be managed outside
+  # of this helm chart.
   fddClusterRole:
     enabled: false
+    # bind the created clusterRole to fiaas-deploy-daemon's serviceAccount in
+    # these namespaces.
     namespaces:
     - default
 manageRBAC: false # have Skipper create RBAC resources for any FDD it deploys

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -41,6 +41,10 @@ annotations: {}
 rbac:
   enabled: false # create RBAC resources giving Skipper the permissions it needs
   enableFIAASController: true # enable the fiaas-controller clusterrole/clusterrolebinding, giving all service accounts great permissions
+  # Bind the fiaas-deploy-daemon clusterrole to the fiaas-deploy-daemon service account in these namespaces.
+  # This is necessary for FDD to be able to create/update the CRD's on startup.
+  fddClusterRoleNamespaces:
+  - default
 manageRBAC: false # have Skipper create RBAC resources for any FDD it deploys
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -43,8 +43,10 @@ rbac:
   enableFIAASController: true # enable the fiaas-controller clusterrole/clusterrolebinding, giving all service accounts great permissions
   # Bind the fiaas-deploy-daemon clusterrole to the fiaas-deploy-daemon service account in these namespaces.
   # This is necessary for FDD to be able to create/update the CRD's on startup.
-  fddClusterRoleNamespaces:
-  - default
+  fddClusterRole:
+    enabled: false
+    namespaces:
+    - default
 manageRBAC: false # have Skipper create RBAC resources for any FDD it deploys
 statusUpdateInterval: 30
 # Add a fiaas-deploy-daemon configmap to the namespace where fiaas-skipper is installed


### PR DESCRIPTION
We recently discovered that fiaas-deploy-daemon is missing cluster wide permissions to get/create/update our CRD's, something it does on startup. This necessitates a clusterrole since CRD's are scoped at the cluster level. It would be a lot of work to implement this in Skipper's code, especially considering that the models would also need to be implemented in the k8s library. Therefore a simple addition to the helm chart is what we've included here, with a list of namespaces in which the clusterrole should be bound to fiaas-deploy-daemon serviceAccounts.