### PR TITLE
Fix CI build issue with setuptools_scm 7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     zip_safe=False,
     # Requirements
     install_requires=GENERIC_REQ + WEB_REQ,
-    setup_requires=['pytest-runner', 'wheel', 'setuptools_scm'],
+    setup_requires=['pytest-runner', 'wheel', 'setuptools_scm==6.4.2'],
     extras_require={
         "dev": TESTS_REQ + CODE_QUALITY_REQ + CI_REQ,
         "ci": CI_REQ,


### PR DESCRIPTION
setuptools_scm 7.0.0 and later do not support python 3.6, which makes the CI build fail with a SyntaxError. Pin setuptools_scm to the latest 6.x release. 
