### PR TITLE
feat: allow disabling ingress

### DIFF
--- a/helm/fiaas-skipper/templates/ingress.yaml
+++ b/helm/fiaas-skipper/templates/ingress.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.ingress.enabled }}
 apiVersion: {{ if .Values.ingress.useNetworkingV1 }}networking.k8s.io/v1{{ else }}extensions/v1beta1{{ end }}
 kind: Ingress
 metadata:
@@ -57,4 +58,5 @@ spec:
           serviceName: "{{ .Values.name }}"
           servicePort: 5000
         path: /
+{{- end }}
 {{- end }}

--- a/helm/fiaas-skipper/values.yaml
+++ b/helm/fiaas-skipper/values.yaml
@@ -19,6 +19,7 @@ image:
   tag: "latest"
   pullPolicy: Always
 ingress:
+  enabled: true
   useNetworkingV1: false
   fqdn: fiaas-skipper.yourcluster.local
   enableTLS: true


### PR DESCRIPTION
as in certain scenarios it is neither useful nor desirable (fully disconnected clusters)

Default behavior should be unchanged.